### PR TITLE
rename Rating.comment to Rating.ratingComment

### DIFF
--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -364,11 +364,11 @@
                 <td>Optional</td>
             </tr>
             <tr>
-                <td>comment</td>
+                <td>ratingComment</td>
                 <td><a href="#entity-comment">Comment</a> | <a href=
                    "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
                 >IRI</a></td>
-                <td>The <code>Comment</code> left with the <code>Rating</code>. The <code>comment</code> value MUST be expressed either as an
+                <td>The <code>Comment</code> left with the <code>Rating</code>. The <code>ratingComment</code> value MUST be expressed either as an
                     object or as a string corresponding to the comment’s IRI.
                 </td>
                 <td>Optional</td>
@@ -891,7 +891,7 @@
       "dateCreated": "2018-08-01T06:00:00.000Z"
     },
     "selections": ["1"],
-    "comment": {
+    "ratingComment": {
       "id": "https://example.edu/terms/201801/courses/7/sections/1/assess/1/items/6/users/665544/responses/1/comment/1",
       "type": "Comment",
       "commenter": {
@@ -1097,7 +1097,7 @@
     "itemValues": [-2, -1, 1, 2]
   },
   "selections": ["1"],
-  "comment": {
+  "ratingComment": {
     "id": "https://example.edu/terms/201801/courses/7/sections/1/assess/1/items/6/users/665544/responses/1/comment/1",
     "type": "Comment",
     "commenter": {


### PR DESCRIPTION
As we already have a `comment` term in our context vocabulary, and it's typed in the context document as a `string` value, using `comment` as reference to an Entity in the Feedback profile would be awkward and troublesome.

We can accommodate by simply renaming Rating.comment to Rating.ratingComment so we have two different terms.

See also:
- [caliper-central issue #212](https://github.com/IMSGlobal/caliper-central/issues/212) for this issue 
- base issue for Feedback profile [caliper central 194](https://github.com/IMSGlobal/caliper-central/issues/194)
