### PR TITLE
Change Person which gave ... to Person who provided ... .

### DIFF
--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -422,7 +422,7 @@
                 >Person</a> | <a href=
                     "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
                 >IRI</a></td>
-                <td>The <code>Person</code> which gave the comment. The <code>commenter</code> value MUST be
+                <td>The <code>Person</code> who provided the comment. The <code>commenter</code> value MUST be
                     expressed either as an object or as a string corresponding to the commenter’s IRI.
                 </td>
                 <td>Optional</td>


### PR DESCRIPTION
This fix adjusts the phrasing of the commenter property description. Changes

"Person which gave . . . "
to
"Person who provided . . ."