### PR TITLE
ToolUse Profile and Feedback Profile updates

### DIFF
--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -580,7 +580,7 @@
             <dd><code>MultiselectScale</code> inherits all properties defined by its supertype <code>Scale</code>,
                 of which<code>id</code>, and <code>type</code> are required. <code>MultiselectScale</code> is also
                 provisioned with six additional properties <code>scalePoints</code>, <code>itemLabels</code>,
-                <code>itemValues</code>, <code>orderedSelection</code>, <code>minSelections</code>, and
+                <code>itemValues</code>, <code>isOrderedSelection</code>, <code>minSelections</code>, and
                 <code>maxSelections</code>. Profile-specific type restrictions are described below:
             </dd>
         </dl>
@@ -622,7 +622,7 @@
                 <td>Optional</td>
             </tr>
             <tr>
-                <td>orderedSelection</td>
+                <td>isOrderedSelection</td>
                 <td>boolean</td>
                 <td>Indicates whether the order of the selected items is important.</td>
                 <td>Optional</td>
@@ -1023,7 +1023,7 @@
   "scalePoints": 5,
   "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
   "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
-  "orderedSelection": false,
+  "isOrderedSelection": false,
   "minSelections": 1,
   "maxSelections": 5,
   "dateCreated": "2018-08-01T06:00:00.000Z"
@@ -1162,7 +1162,7 @@
     "scalePoints": 5,
     "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
     "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
-    "orderedSelection": false,
+    "isOrderedSelection": false,
     "minSelections": 1,
     "maxSelections": 5,
     "dateCreated": "2018-08-01T06:00:00.000Z"

--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -553,13 +553,13 @@
             <tr>
                 <td>itemLabels</td>
                 <td>Array [{key:value}] | Array [value]</td>
-                <td>The ordered list of labels for each point on the likert scale.</td>
+                <td>The ordered list of labels for each point on the Likert scale.</td>
                 <td>Optional</td>
             </tr>
             <tr>
                 <td>itemValues</td>
                 <td>Array [{key:value}] | Array [value]</td>
-                <td>The ordered list of values for each point on the likert scale.</td>
+                <td>The ordered list of values for each point on the Likert scale.</td>
                 <td>Optional</td>
             </tr>
             </tbody>

--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -989,7 +989,9 @@
 
         <p>Below is an example of a <a href="#entity-likert-scale">LikertScale</a> entity describe that
             can also be sent to an endpoint. The <a href="#entity-likert-scale">LikertScale</a>
-            references the question, points, item labels, and item values.</p>
+            references the <code>question</code>, <code>scalePoints</code>, <code>itemLabels</code>,
+            and <code>itemValues</code>.
+        </p>
 
         <figure class="example">
             <figcaption><code>LikertScale</code> describe JSON-LD</figcaption>
@@ -1011,7 +1013,8 @@
 
         <p>Below is an example of a <a href="#entity-multiselect-scale">MultiselectScale</a> entity describe that
             can also be sent to an endpoint. The <a href="#entity-multiselect-scale">MultiselectScale</a>
-            references the question, item labels, item values, ordering (if any), and selection range.</p>
+            references the <code>question</code>, <code>itemLabels</code>, <code>itemValues</code>, ordering (if any),
+            and selection range.</p>
 
         <figure class="example">
             <figcaption><code>MultiselectScale</code> describe JSON-LD</figcaption>

--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -521,7 +521,7 @@
             <dt>Properties</dt>
             <dd><code>LikertScale</code> inherits all properties defined by its supertype <code>Scale</code>, of which
                 <code>id</code>, and <code>type</code> are required. <code>LikertScale</code> is also provisioned
-                with three additional properties <code>points</code>, <code>itemLabels</code>, and
+                with three additional properties <code>scalePoints</code>, <code>itemLabels</code>, and
                 <code>itemValues</code>. Profile-specific type restrictions are described below:
             </dd>
         </dl>
@@ -545,7 +545,7 @@
                 <td>Required</td>
             </tr>
             <tr>
-                <td>points</td>
+                <td>scalePoints</td>
                 <td>integer</td>
                 <td>A integer value used to determine the amount of points on the <code>LikertScale</code>.</td>
                 <td>Optional</td>
@@ -579,7 +579,7 @@
             <dt>Properties</dt>
             <dd><code>MultiselectScale</code> inherits all properties defined by its supertype <code>Scale</code>,
                 of which<code>id</code>, and <code>type</code> are required. <code>MultiselectScale</code> is also
-                provisioned with six additional properties <code>points</code>, <code>itemLabels</code>,
+                provisioned with six additional properties <code>scalePoints</code>, <code>itemLabels</code>,
                 <code>itemValues</code>, <code>orderedSelection</code>, <code>minSelections</code>, and
                 <code>maxSelections</code>. Profile-specific type restrictions are described below:
             </dd>
@@ -604,7 +604,7 @@
                 <td>Required</td>
             </tr>
             <tr>
-                <td>points</td>
+                <td>scalePoints</td>
                 <td>integer</td>
                 <td>A integer value used to determine the amount of points on the <code>MultiselectScale</code>.</td>
                 <td>Optional</td>
@@ -884,7 +884,7 @@
     "scale": {
       "id": "https://example.edu/scale/2",
       "type": "LikertScale",
-      "points": 4,
+      "scalePoints": 4,
       "question": "Do you agree with the opinion presented?",
       "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
       "itemValues": [-2, -1, 1, 2],
@@ -998,7 +998,7 @@
   "id": "https://example.edu/scale/2",
   "type": "LikertScale",
   "question": "Do you agree with the opinion presented?",
-  "points": 4,
+  "scalePoints": 4,
   "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
   "itemValues": [-2, -1, 1, 2],
   "dateCreated": "2018-08-01T06:00:00.000Z"
@@ -1020,7 +1020,7 @@
   "id": "https://example.edu/scale/3",
   "type": "MultiselectScale",
   "question": "How do you feel about this content? (select one or more)",
-  "points": 5,
+  "scalePoints": 5,
   "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
   "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
   "orderedSelection": false,
@@ -1091,7 +1091,7 @@
   "scale": {
     "id": "https://example.edu/scale/2",
     "type": "LikertScale",
-    "points": 4,
+    "scalePoints": 4,
     "question": "Do you agree with the opinion presented?",
     "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
     "itemValues": [-2, -1, 1, 2]
@@ -1159,7 +1159,7 @@
     "id": "https://example.edu/scale/3",
     "type": "MultiselectScale",
     "question": "How do you feel about this content? (select one or more)",
-    "points": 5,
+    "scalePoints": 5,
     "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
     "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
     "orderedSelection": false,

--- a/profiles/tooluse/caliper-profile-tool_use-v1p1.html
+++ b/profiles/tooluse/caliper-profile-tool_use-v1p1.html
@@ -308,7 +308,7 @@
             </tr>
             <td>metricValue</td>
             <td>integer</td>
-            <td>A Number representing the total curricular progress the actor has made in the context of the
+            <td>An integer value representing the total curricular progress the actor has made in the context of the
                 application.
             </td>
             <td>Required</td>
@@ -316,7 +316,7 @@
             <tr>
                 <td>metricValueMax</td>
                 <td>integer</td>
-                <td>A Number representing the total possible curricular progress the actor can make in the context of
+                <td>An integer value representing the total possible curricular progress the actor can make in the context of
                     the application.
                 </td>
                 <td>Optional</td>

--- a/profiles/tooluse/caliper-profile-tool_use-v1p1.html
+++ b/profiles/tooluse/caliper-profile-tool_use-v1p1.html
@@ -243,7 +243,7 @@
 <section id="actions">
     <h2>Actions</h2>
 
-    <p>The Caliper <a href="#toolUseEvent">ToolUse Event</a> supports the <em>Used</em> action only.</p>
+    <p>The Caliper <a href="#toolUseEvent">ToolUseEvent</a> supports the <em>Used</em> action only.</p>
 
     <section id="action-Used">
         <h3>Used</h3>
@@ -410,7 +410,7 @@
 <section id="metrics">
     <h2>Metrics</h2>
     <p>The <a href="#entity-aggregateMeasure">AggregateMeasure</a> entity includes a required <code>metric</code>
-        property for denoting the metric related to the <a href="#toolUseEvent">ToolUse Event</a>. Metric values are
+        property for denoting the metric related to the <a href="#toolUseEvent">ToolUseEvent</a>. Metric values are
         limited to the list of Caliper terms listed below</p>
 
     <section id="metric-AssessmentsSubmitted">
@@ -421,7 +421,7 @@
             <dt>Term</dt>
             <dd>AssessmentsSubmitted</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/AssessmentsSubmitted</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/AssessmentsSubmitted</dd>
         </dl>
     </section>
 
@@ -433,7 +433,7 @@
             <dt>Term</dt>
             <dd>AssessmentsPassed</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/AssessmentsPassed</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/AssessmentsPassed</dd>
         </dl>
     </section>
 
@@ -445,7 +445,7 @@
             <dt>Term</dt>
             <dd>MinutesOnTask</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/MinutesOnTask</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/MinutesOnTask</dd>
         </dl>
     </section>
 
@@ -457,7 +457,7 @@
             <dt>Term</dt>
             <dd>SkillsMastered</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/SkillsMastered</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/SkillsMastered</dd>
         </dl>
     </section>
 
@@ -469,7 +469,7 @@
             <dt>Term</dt>
             <dd>StandardsMastered</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/StandardsMastered</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/StandardsMastered</dd>
         </dl>
     </section>
 
@@ -481,7 +481,7 @@
             <dt>Term</dt>
             <dd>UnitsCompleted</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/UnitsCompleted</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/UnitsCompleted</dd>
         </dl>
     </section>
 
@@ -494,7 +494,7 @@
             <dt>Term</dt>
             <dd>UnitsPassed</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/UnitsPassed</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/UnitsPassed</dd>
         </dl>
     </section>
 
@@ -506,7 +506,7 @@
             <dt>Term</dt>
             <dd>WordsRead</dd>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/WordsRead</dd>
+            <dd>https://purl.imsglobal.org/caliper/metrics/WordsRead</dd>
         </dl>
     </section>
 </section>

--- a/profiles/tooluse/caliper-profile-tool_use-v1p1.html
+++ b/profiles/tooluse/caliper-profile-tool_use-v1p1.html
@@ -314,7 +314,7 @@
             <td>Required</td>
             </tr>
             <tr>
-                <td>metricValueMax</td>
+                <td>maxMetricValue</td>
                 <td>integer</td>
                 <td>An integer value representing the total possible curricular progress the actor can make in the context of
                     the application.
@@ -580,7 +580,7 @@
       "id": "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d988",
       "type": "AggregateMeasure",
       "metricValue": "12",
-      "metricValueMax": "25",
+      "maxMetricValue": "25",
       "metric": "AssessmentsPassed",
       "name": "End of Chapter Assessments Passed",
       "description": "Number of end of chapter assessments successfully passed on first or second attempt",
@@ -619,7 +619,7 @@
   "id":"urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d933",
   "type":"AggregateMeasure",
   "metricValue": "12",
-  "metricValueMax": "25",
+  "maxMetricValue": "25",
   "metric": "AssessmentsPassed",
   "name": "End of Chapter Assessments Passed",
   "description": "Number of end of chapter assessments successfully passed on first or second attempt",
@@ -656,7 +656,7 @@
       "id": "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d918",
       "type": "AggregateMeasure",
       "metricValue": "12",
-      "metricValueMax": "25",
+      "maxMetricValue": "25",
       "metric": "AssessmentsPassed",
       "name": "End of Chapter Assessments Passed",
       "description": "Number of end of chapter assessments successfully passed on first or second attempt",

--- a/profiles/tooluse/caliper-profile-tool_use-v1p1.html
+++ b/profiles/tooluse/caliper-profile-tool_use-v1p1.html
@@ -307,7 +307,7 @@
                 <td>Required</td>
             </tr>
             <td>metricValue</td>
-            <td>Number</td>
+            <td>integer</td>
             <td>A Number representing the total curricular progress the actor has made in the context of the
                 application.
             </td>
@@ -315,7 +315,7 @@
             </tr>
             <tr>
                 <td>metricValueMax</td>
-                <td>Number</td>
+                <td>integer</td>
                 <td>A Number representing the total possible curricular progress the actor can make in the context of
                     the application.
                 </td>

--- a/profiles/tooluse/caliper-profile-tool_use-v1p1.html
+++ b/profiles/tooluse/caliper-profile-tool_use-v1p1.html
@@ -279,8 +279,8 @@
             </dd>
             <dt>Supertype</dt>
             <dd><a href=
-                           "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#eventDef"
-            >Event</a></dd>
+                           "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#entityDef"
+            >Entity</a></dd>
             <dt>Properties</dt>
             <dd><code>AggregateMeasure</code> inherits all the properties and requirements defined for its
                 supertype <a href="#entity">Entity</a>, of which <code>id</code>, and <code>type</code> are required.
@@ -365,8 +365,8 @@
             </dd>
             <dt>Supertype</dt>
             <dd><a href=
-               "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#eventDef"
-            >Event</a></dd>
+               "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#entityDef"
+            >Entity</a></dd>
             <dt>Properties</dt>
             <dd><code>AggregateMeasureCollection</code> inherits all the properties and requirements defined for its
                 supertype <a href="#entity">Entity</a>, of which <code>id</code>, and <code>type</code> are required.


### PR DESCRIPTION
This PR implements the following:

1. ToolUse Profile: adds "/metric/" to Metric enum IRIs per https://github.com/IMSGlobal/caliper-central/issues/217
2. ToolUse Profile: changes `metricValueMax` property name to `maxMetricValue` (aligns with use of "max" as a prefix)
3. Feedback Profile: changes `points` to `scalePoints` per https://github.com/IMSGlobal/caliper-spec/issues/373
4. Feedback Profile: changes `orderedSelection` to `isOrderedSelection` per https://github.com/IMSGlobal/caliper-spec/issues/374
4. ToolUse Profile, Feedback Profile: fixes various typos.