### PR TITLE
 Modified how scales and questions relate 

### DIFF
--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -656,8 +656,7 @@
             >Entity</a></dd>
             <dt>Properties</dt>
             <dd><code>Scale</code> inherits all properties defined by its supertype <code>Entity</code>, of which
-                <code>id</code>, and <code>type</code> are required. <code>Scale</code> is also provisioned with an
-                additional <code>question</code> property. Profile-specific type restrictions are described below:
+                <code>id</code>, and <code>type</code> are required.  Profile-specific type restrictions are described below:
             </dd>
         </dl>
 
@@ -678,12 +677,6 @@
                 >Term</a></td>
                 <td>The string value MUST be set to the Term <em>Scale</em>.</td>
                 <td>Required</td>
-            </tr>
-            <tr>
-                <td>question</td>
-                <td>string</td>
-                <td>A string value comprising the question posed to be scaled.</td>
-                <td>Optional</td>
             </tr>
             </tbody>
         </table>

--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -300,8 +300,8 @@
             <dd><code>Rating</code> inherits all properties defined by its supertype
                 <code>Entity</code>, of which <code>id</code>, and <code>type</code> are required.
                 <code>Rating</code> is also provisioned with additional properties, <code>rater</code>,
-                <code>rated</code>, <code>scaleQuestion</code>, <code>selections</code>, and <code>comment</code>.
-                Profile-specific type restrictions are described below:
+                <code>rated</code>, <code>question</code>, <code>selections</code>,
+                and <code>comment</code>. Profile-specific type restrictions are described below:
             </dd>
         </dl>
 
@@ -348,12 +348,12 @@
                 <td>Optional</td>
             </tr>
             <tr>
-                <td>scaleQuestion</td>
-                <td><a href="#entity-scale-question">ScaleQuestion</a> | <a href=
+                <td>question</td>
+                <td><a href="#entity-question">Question</a> | <a href=
                    "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
                 >IRI</a></td>
-                <td>The <code>ScaleQuestion</code> used for the <code>Rating</code>. The <code>scaleQuestion</code>
-                    value MUST be expressed either as an object or as a string corresponding to the scale's IRI.
+                <td>The <code>Question</code> used for the <code>Rating</code>. The <code>question</code>
+                    value MUST be expressed either as an object or as a string corresponding to the question's IRI.
                 </td>
                 <td>Optional</td>
             </tr>
@@ -493,19 +493,19 @@
         </table>
     </section>
 
-    <section id="entity-scale-question">
-        <h3>ScaleQuestion</h3>
+    <section id="entity-rating-scale-question">
+        <h3>RatingScaleQuestion</h3>
 
         <dl>
             <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/ScaleQuestion</dd>
+            <dd>https://purl.imsglobal.org/caliper/RatingScaleQuestion</dd>
             <dt>Supertype</dt>
-            <dd><a href="#entity-question">Question</a>, <a href="#entity-scale">Scale</a></dd>
+            <dd><a href="#entity-question">Question</a></dd>
             <dt>Properties</dt>
-            <dd><code>ScaleQuestion</code> inherits all properties defined by its supertypes
-              <code>Question</code> and <code>Scale</code>,
-              of which <code>id</code> and <code>type</code> are required.
-              Profile-specific type restrictions are described below:
+            <dd><code>RatingScaleQuestion</code> inherits all properties defined by its supertype
+              <code>Question</code>, of which <code>id</code> and <code>type</code> are required.
+              <code>RatingScaleQuestion</code> is also provisioned with the additional property
+              <code>scale</code>. Profile-specific type restrictions are described below:
             </dd>
         </dl>
 
@@ -523,120 +523,18 @@
                 <td>type</td>
                 <td><a href="https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
                 >Term</a></td>
-                <td>The string value MUST be set to the Term 'ScaleQuestion'.</td>
+                <td>The string value MUST be set to the Term 'RatingScaleQuestion'.</td>
                 <td>Required</td>
             </tr>
-            </tbody>
-        </table>
-    </section>
-
-    <section id="entity-likert-scale-question">
-        <h3>LikertScaleQuestion</h3>
-
-        <dl>
-            <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/LikertScaleQuestion</dd>
-            <dt>Supertype</dt>
-            <dd><a href="#entity-scale-question">ScaleQuestion</a>, <a href="#entity-likert-scale">LikertScale</a></dd>
-            <dt>Properties</dt>
-            <dd><code>LikertScaleQuestion</code> inherits all properties defined by its supertypes
-              <code>Question</code> and <code>LikertScale</code>,
-              of which <code>id</code> and <code>type</code> are required.
-              Profile-specific type restrictions are described below:
-            </dd>
-        </dl>
-
-        <table class="data">
-            <thead>
             <tr>
-                <th>Property</th>
-                <th>Type</th>
-                <th>Description</th>
-                <th>Disposition</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>type</td>
-                <td><a href="https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
-                >Term</a></td>
-                <td>The string value MUST be set to the Term 'LikertScaleQuestion'.</td>
-                <td>Required</td>
-            </tr>
-            </tbody>
-        </table>
-    </section>
-
-
-    <section id="entity-likert-scale-question">
-        <h3>MultiselectScaleQuestion</h3>
-
-        <dl>
-            <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/MultiselectScaleQuestion</dd>
-            <dt>Supertype</dt>
-            <dd><a href="#entity-scale-question">ScaleQuestion</a>, <a href="#entity-multiselection-scale">MultiselectionScale</a></dd>
-            <dt>Properties</dt>
-            <dd><code>MultiselectScaleQuestion</code> inherits all properties defined by its supertypes
-              <code>Question</code> and <code>MultiselectionScale</code>,
-              of which <code>id</code> and <code>type</code> are required.
-              Profile-specific type restrictions are described below:
-            </dd>
-        </dl>
-
-        <table class="data">
-            <thead>
-            <tr>
-                <th>Property</th>
-                <th>Type</th>
-                <th>Description</th>
-                <th>Disposition</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>type</td>
-                <td><a href="https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
-                >Term</a></td>
-                <td>The string value MUST be set to the Term 'MultiselectScaleQuestion'.</td>
-                <td>Required</td>
-            </tr>
-            </tbody>
-        </table>
-    </section>
-
-    <section id="entity-numeric-scale-question">
-        <h3>NumericScaleQuestion</h3>
-
-        <dl>
-            <dt>IRI</dt>
-            <dd>https://purl.imsglobal.org/caliper/NumericScaleQuestion</dd>
-            <dt>Supertype</dt>
-            <dd><a href="#entity-scale-question">ScaleQuestion</a>, <a href="#entity-numeric-scale">NumericScale</a></dd>
-            <dt>Properties</dt>
-            <dd><code>NumericScaleQuestion</code> inherits all properties defined by its supertypes
-              <code>Question</code> and <code>NumericScale</code>,
-              of which <code>id</code> and <code>type</code> are required.
-              Profile-specific type restrictions are described below:
-            </dd>
-        </dl>
-
-        <table class="data">
-            <thead>
-            <tr>
-                <th>Property</th>
-                <th>Type</th>
-                <th>Description</th>
-                <th>Disposition</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>type</td>
-                <td><a href="https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
-                >Term</a></td>
-                <td>The string value MUST be set to the Term 'NumericScaleQuestion'.</td>
-                <td>Required</td>
+                <td>scale</td>
+                <td><a href="#entity-scale">Scale</a> | <a href=
+                    "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
+                >IRI</a></td>
+                <td>The <code>Scale</code> used in the question. The <code>scale</code> value MUST be
+                    expressed either as an object or as a string corresponding to the scale's IRI.
+                </td>
+                <td>Optional</td>
             </tr>
             </tbody>
         </table>
@@ -908,8 +806,9 @@
           "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension">context</a>
         for mapping <code>FeedbackEvent</code> terms to IRIs. Caliper message producers MUST reference this
         context in every Caliper 1.1 <code>FeedbackEvent</code>, <code>Rating</code>, <code>Comment</code>,
-        <code>Scale</code>, <code>LikertScale</code>, <code>MultiselectScale</code>, and/or
-        <code>NumericScale</code> describe created and serialized for transmission to a target endpoint.</p>
+        <code>Question</code>, <code>RatingScaleQuestion</code>, <code>Scale</code>, <code>LikertScale</code>,
+        <code>MultiselectScale</code>, and/or <code>NumericScale</code> describe created and serialized for
+        transmission to a target endpoint.</p>
 
     <p>See the Caliper 1.1 specification [[!CALIPER-11]] for a discussion of JSON-LD and JSON-LD
         context handling.</p>
@@ -1065,14 +964,17 @@
       },
       "dateCreated": "2018-08-02T11:32:00.000Z"
     },
-    "scaleQuestion": {
-      "id": "https://example.edu/question/3",
-      "type": "LikertScaleQuestion",
-      "scalePoints": 4,
+    "question": {
+      "id": "https://example.edu/question/2",
+      "type": "RatingScaleQuestion",
       "questionPosed": "Do you agree with the opinion presented?",
-      "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-      "itemValues": [-2, -1, 1, 2],
-      "dateCreated": "2018-08-01T06:00:00.000Z"
+      "scale": {
+        "id": "https://example.edu/scale/2",
+        "type": "LikertScale",
+        "scalePoints": 4,
+        "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
+        "itemValues": [-2, -1, 1, 2]
+      }
     },
     "selections": ["1"],
     "ratingComment": {
@@ -1188,88 +1090,23 @@
     </section>
 
     <section class="informative">
-        <h2>ScaleQuestion Describe</h2>
+        <h2>RatingScaleQuestion Describe</h2>
 
         <figure class="example">
-            <figcaption><code>ScaleQuestion</code> describe JSON-LD</figcaption>
+            <figcaption><code>RatingScaleQuestion</code> describe JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "https://example.edu/question/2",
-  "type": "ScaleQuestion",
-  "questionPosed": "What is this generic scale question about?",
-}</code></pre>
-        </figure>
-    </section>
-
-    <section class="informative">
-        <h2>LikertScaleQuestion Describe</h2>
-
-        <p>Below is an example of a <a href="#entity-likert-scale-question">LikertScaleQuestion</a> entity
-            describe that can also be sent to an endpoint. The <a href="#entity-likert-scale-question">LikertScaleQuestion</a>
-            references the <code>questionPosed</code>, <code>scalePoints</code>,
-            <code>itemLabels</code>, and <code>itemValues</code>.</p>
-
-        <figure class="example">
-            <figcaption><code>LikertScaleQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/question/3",
-  "type": "LikertScaleQuestion",
+  "type": "RatingScaleQuestion",
   "questionPosed": "Do you agree with the opinion presented?",
-  "scalePoints": 4,
-  "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-  "itemValues": [-2, -1, 1, 2],
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
-        </figure>
-    </section>
-
-    <section class="informative">
-        <h2>MultiselectQuestion Describe</h2>
-
-        <p>Below is an example of a <a href="#entity-multiselect-scale-question">MultiselectQuestion</a> entity describe that
-            can also be sent to an endpoint. The <a href="#entity-multiselect-scale-question">MultiselectQuestion</a>
-            references the <code>questionPosed</code>, <code>itemLabels</code>,
-            <code>itemValues</code>, ordering (if any), and selection range.</p>
-
-        <figure class="example">
-            <figcaption><code>MultiselectQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/question/4",
-  "type": "MultiselectionScale",
-  "questionPosed": "How do you feel about this content? (select one or more)",
-  "scalePoints": 5,
-  "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
-  "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
-  "isOrderedSelection": false,
-  "minSelections": 1,
-  "maxSelections": 5,
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
-        </figure>
-    </section>
-
-    <section class="informative">
-        <h2>NumericScaleQuestion Describe</h2>
-
-        <p>Below is an example of a <a href="#entity-numeric-scale-question">NumericScaleQuestion</a> entity describe that
-          can also be sent to an endpoint. The <a href="#entity-numeric-scale-question">NumericScaleQuestion</a> references
-          the question posed, value range, steps, and labels.</p>
-
-        <figure class="example">
-            <figcaption><code>NumericScaleQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/question/5",
-  "type": "NumericScaleQuestion",
-  "questionPosed": "How do you feel about this content?",
-  "minValue": 0.0,
-  "minLabel": "Disliked",
-  "maxValue": 10.0,
-  "maxLabel": "Liked",
-  "step": 0.5,
-  "dateCreated": "2018-08-01T06:00:00.000Z"
+  "scale": {
+    "id": "https://example.edu/scale/2",
+    "type": "LikertScale",
+    "scalePoints": 4,
+    "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
+    "itemValues": [-2, -1, 1, 2],
+    "dateCreated": "2018-08-01T06:00:00.000Z"
+  }
 }</code></pre>
         </figure>
     </section>
@@ -1377,13 +1214,17 @@
     },
     "dateCreated": "2018-08-02T11:32:00.000Z"
   },
-  "scaleQuestion": {
-    "id": "https://example.edu/question/3",
-    "type": "LikertScaleQuestion",
-    "scalePoints": 4,
+  "question": {
+    "id": "https://example.edu/question/2",
+    "type": "RatingScaleQuestion",
     "questionPosed": "Do you agree with the opinion presented?",
-    "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-    "itemValues": [-2, -1, 1, 2]
+    "scale": {
+      "id": "https://example.edu/scale/2",
+      "type": "LikertScale",
+      "scalePoints": 4,
+      "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
+      "itemValues": [-2, -1, 1, 2]
+    }
   },
   "selections": ["1"],
   "ratingComment": {
@@ -1444,17 +1285,20 @@
       "type": "CourseSection"
     }
   },
-  "scale": {
-    "id": "https://example.edu/scale/3",
-    "type": "MultiselectScale",
+  "question": {
+    "id": "https://example.edu/question/3",
+    "type": "RatingScaleQuestion",
     "questionPosed": "How do you feel about this content? (select one or more)",
-    "scalePoints": 5,
-    "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
-    "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
-    "isOrderedSelection": false,
-    "minSelections": 1,
-    "maxSelections": 5,
-    "dateCreated": "2018-08-01T06:00:00.000Z"
+    "scale": {
+      "id": "https://example.edu/scale/3",
+      "type": "MultiselectScale",
+      "scalePoints": 5,
+      "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
+      "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
+      "isOrderedSelection": false,
+      "minSelections": 1,
+      "maxSelections": 5
+    }
   },
   "selections": ["superhappy", "disappointed"],
   "dateCreated": "2018-08-01T06:00:00.000Z"


### PR DESCRIPTION
- Renamed ScaleQuestion -> RatingScaleQuestion
- renamed Rating.scaleQuestion to Rating.question
- Added scale<Scale> property in RatingScaleQuestion
- Removed LikertScaleQuestion, MultiselectScaleQuestion, and NumericScaleQuestion entities
- Remove mistaken `Scale.question` 

Now rating can contain a question and if it is a RatingScaleQuestion it can contains a Scale (instead of combining the question and scale in LikertScaleQuestion, etc entities)