### PR TITLE
Reorganize JSON-LD example sections; change itemValue values to strings.

### DIFF
--- a/profiles/survey/caliper-profile-survey-v1p1.html
+++ b/profiles/survey/caliper-profile-survey-v1p1.html
@@ -1943,20 +1943,17 @@
 </section>
 
 <section id="jsonld">
-  <h2>Expressing Caliper as JSON-LD</h2>
+  <h2>Caliper JSON-LD Examples</h2>
 
   <p>Individual Caliper events and entity describes are serialized as JSON-LD. IMS Global
     provides a remote Survey Profile JSON-LD <a href=
       "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension">context</a> for mapping
     <code>SurveyEvent</code>, <code>SurveyInvitationEvent</code>, <code>QuestionnaireEvent</code>,
-    and <code>QuestionnaireItemEvent</code> terms to IRIs. Caliper message producers MUST reference this
-    context in every Caliper 1.1 <code>SurveyEvent</code>, <code>SurveyInvitationEvent</code>,
-    <code>QuestionnaireEvent</code>, <code>QuestionnaireItemEvent</code>, <code>Collection</code>,
-    <code>Survey</code>, <code>Questionnaire</code>, <code>QuestionnaireItem</code>, <code>ScaleQuestion</code>,
-    <code>DateTimeQuestion</code>, <code>MultiselectQuestion</code>, <code>OpenEndedQuestion</code>,
-    <code>RatingScaleResponse</code>, <code>DateTimeResponse</code>, <code>MultiselectResponse</code>,
-    <code>OpenEndedResponse</code>, and/or <code>SurveyInvitation</code> describe created
-    and serialized for transmission to a target endpoint.</p>
+    <code>QuestionnaireItemEvent</code>, <code>NavigationEvent</code>, and <code>ViewEvent</code> terms to IRIs.
+    Caliper message producers MUST reference the Survey Profile 1.1-extension context in every <code>Event</code>
+    subtype described in this profile. Likewise, Caliper message producers MUST reference the Survey
+    Profile 1.1-extension context whenever an <code>Entity</code> subtype described in this profile is emitted on
+    its own as a <em>describe</em>.</p>
 
   <p>See the Caliper 1.1 specification [[!CALIPER-11]] for a discussion of JSON-LD and JSON-LD
     context handling.</p>
@@ -1970,11 +1967,17 @@
   </figure>
 
   <section class="informative">
-    <h2>OptedIn SurveyEvent</h2>
+    <h2>Events</h2>
 
-    <figure class="example">
-      <figcaption><code>SurveyEvent</code> OptedIn JSON-LD</figcaption>
-<pre><code>{
+    <section class="informative">
+      <h2>SurveyEvent</h2>
+
+      <section class="informative">
+        <h2>OptedIn</h2>
+
+        <figure class="example">
+          <figcaption><code>SurveyEvent</code> OptedIn JSON-LD</figcaption>
+  <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:4bfb7726-3564-11e9-b210-d663bd873d93",
   "type": "SurveyEvent",
@@ -2010,14 +2013,18 @@
     "startedAtTime": "2018-11-15T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
+    </section>
 
-  <section class="informative">
-    <h2>Accepted SurveyInvitationEvent</h2>
+    <section class="informative">
+      <h2>SurveyInvitationEvent</h2>
 
-    <figure class="example">
-      <figcaption><code>SurveyInvitationEvent</code> Accepted JSON-LD</figcaption>
+      <section class="informative">
+        <h2>Accepted</h2>
+
+        <figure class="example">
+          <figcaption><code>SurveyInvitationEvent</code> Accepted JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:534afa10-3564-11e9-b210-d663bd873d93",
@@ -2065,14 +2072,14 @@
     "startedAtTime": "2018-11-15T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
 
-  <section class="informative">
-    <h2>Sent SurveyInvitationEvent</h2>
+      <section class="informative">
+        <h2>Sent</h2>
 
-    <figure class="example">
-      <figcaption><code>SurveyInvitationEvent</code> Sent JSON-LD</figcaption>
+        <figure class="example">
+          <figcaption><code>SurveyInvitationEvent</code> Sent JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:5801f73e-3564-11e9-b210-d663bd873d93",
@@ -2120,14 +2127,18 @@
     "startedAtTime": "2018-11-12T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
+    </section>
 
-  <section class="informative">
-    <h2>Started QuestionnaireEvent</h2>
+    <section class="informative">
+      <h2>QuestionnaireEvent</h2>
 
-    <figure class="example">
-      <figcaption><code>QuestionnaireEvent</code> Started JSON-LD</figcaption>
+      <section class="informative">
+        <h2>Started</h2>
+
+      <figure class="example">
+        <figcaption><code>QuestionnaireEvent</code> Started JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93",
@@ -2175,14 +2186,14 @@
     "startedAtTime": "2018-11-12T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
 
-  <section class="informative">
-    <h2>Completed QuestionnaireEvent</h2>
+      <section class="informative">
+        <h2>Completed</h2>
 
-    <figure class="example">
-      <figcaption><code>QuestionnaireEvent</code> Completed JSON-LD</figcaption>
+        <figure class="example">
+          <figcaption><code>QuestionnaireEvent</code> Completed JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:79f18ac2-3c6b-11e9-b210-d663bd873d93",
@@ -2230,14 +2241,18 @@
     "startedAtTime": "2018-11-12T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
+    </section>
 
-  <section class="informative">
-    <h2>Started QuestionnaireItemEvent</h2>
+    <section class="informative">
+      <h2>QuestionnaireItemEvent</h2>
 
-    <figure class="example">
-      <figcaption><code>QuestionnaireItemEvent</code> Started JSON-LD</figcaption>
+    <section class="informative">
+      <h2>Started</h2>
+
+      <figure class="example">
+        <figcaption><code>QuestionnaireItemEvent</code> Started JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93",
@@ -2259,7 +2274,7 @@
         "type": "LikertScale",
         "points": 4,
         "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-        "itemValues": [-2, -1, 1, 2]
+        "itemValues": ["-2", "-1", "1", "2"]
       }
     },
     "categories": ["teaching effectiveness", "Course structure"],
@@ -2288,82 +2303,14 @@
     "startedAtTime": "2018-11-12T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
 
+      <section class="informative">
+        <h2>Submitted (OpenEndedQuestion)</h2>
 
-  <section class="informative">
-    <h2>Submitted (RatingScaleQuestion) QuestionnaireItemEvent</h2>
-
-    <figure class="example">
-      <figcaption><code>QuestionnaireItemEvent</code> Submitted JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93",
-  "type": "QuestionnaireItemEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Submitted",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-    "type": "QuestionnaireItem",
-    "question": {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
-      "type": "RatingScaleQuestion",
-      "questionPosed": "How satisfied are you with our services?",
-      "scale": {
-        "id": "https://example.edu/scale/2",
-        "type": "LikertScale",
-        "points": 4,
-        "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-        "itemValues": [-2, -1, 1, 2]
-      }
-    },
-    "categories": ["teaching effectiveness", "Course structure"],
-    "weight": 1.0
-  },
-  "generated": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/1/users/554433/responses/1",
-    "type": "RatingScaleResponse",
-    "selections": ["Satisfied"],
-    "startedAtTime": "2018-08-01T05:55:48.000Z",
-    "endedAtTime": "2018-08-01T06:00:00.000Z",
-    "duration": "PT4M12S"
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>Submitted (OpenEndedQuestion) QuestionnaireItemEvent</h2>
-
-    <figure class="example">
-      <figcaption><code>QuestionnaireItemEvent</code> Submitted JSON-LD</figcaption>
+        <figure class="example">
+          <figcaption><code>QuestionnaireItemEvent</code> Submitted JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93",
@@ -2416,14 +2363,85 @@
     "startedAtTime": "2018-11-12T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
 
-  <section class="informative">
-    <h2>NavigatedTo NavigationEvent</h2>
+      <section class="informative">
+        <h2>Submitted (RatingScaleQuestion)</h2>
 
-    <figure class="example">
-      <figcaption><code>NavigationEvent</code> NavigatedTo JSON-LD</figcaption>
+        <figure class="example">
+          <figcaption><code>QuestionnaireItemEvent</code> Submitted JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93",
+  "type": "QuestionnaireItemEvent",
+  "actor": {
+    "id": "https://example.edu/users/554433",
+    "type": "Person"
+  },
+  "action": "Submitted",
+  "object": {
+    "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
+    "type": "QuestionnaireItem",
+    "question": {
+      "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
+      "type": "RatingScaleQuestion",
+      "questionPosed": "How satisfied are you with our services?",
+      "scale": {
+        "id": "https://example.edu/scale/2",
+        "type": "LikertScale",
+        "points": 4,
+        "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
+        "itemValues": ["-2", "-1", "1", "2"]
+      }
+    },
+    "categories": ["teaching effectiveness", "Course structure"],
+    "weight": 1.0
+  },
+  "generated": {
+    "id": "https://example.edu/surveys/100/questionnaires/30/items/1/users/554433/responses/1",
+    "type": "RatingScaleResponse",
+    "selections": ["Satisfied"],
+    "startedAtTime": "2018-08-01T05:55:48.000Z",
+    "endedAtTime": "2018-08-01T06:00:00.000Z",
+    "duration": "PT4M12S"
+    "dateCreated": "2018-08-01T06:00:00.000Z"
+  },
+  "eventTime": "2018-11-12T10:15:00.000Z",
+  "edApp": "https://example.edu",
+  "group": {
+    "id": "https://example.edu/terms/201801/courses/7/sections/1",
+    "type": "CourseSection",
+    "courseNumber": "CPS 435-01",
+    "academicSession": "Fall 2018"
+  },
+  "membership": {
+    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
+    "type": "Membership",
+    "member": "https://example.edu/users/554433",
+    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
+    "roles": [ "Learner" ],
+    "status": "Active",
+    "dateCreated": "2018-08-01T06:00:00.000Z"
+  },
+  "session": {
+    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
+    "type": "Session",
+    "startedAtTime": "2018-11-12T10:00:00.000Z"
+  }
+}</code></pre>
+        </figure>
+      </section>
+    </section>
+
+    <section class="informative">
+      <h2>NavigationEvent</h2>
+
+      <section class="informative">
+        <h2>NavigatedTo</h2>
+
+        <figure class="example">
+          <figcaption><code>NavigationEvent</code> NavigatedTo JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:a9ea1cb9-3445-4f5a-b5e5-44630cc054a9",
@@ -2467,14 +2485,18 @@
     "startedAtTime": "2018-11-12T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
+    </section>
 
-  <section class="informative">
-    <h2>Viewed ViewEvent</h2>
+    <section class="informative">
+      <h2>ViewEvent</h2>
 
-    <figure class="example">
-      <figcaption><code>ViewEvent</code> Viewed JSON-LD</figcaption>
+      <section class="informative">
+        <h2>Viewed</h2>
+
+        <figure class="example">
+          <figcaption><code>ViewEvent</code> Viewed JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "urn:uuid:bc780773-ee1e-49f6-ab2b-fe16eb391dd8",
@@ -2518,97 +2540,19 @@
     "startedAtTime": "2018-11-12T10:00:00.000Z"
   }
 }</code></pre>
-    </figure>
+        </figure>
+      </section>
+    </section>
   </section>
 
   <section class="informative">
-    <h2>Created ResourceManagementEvent</h2>
+    <h2>Entity Describes</h2>
 
-    <figure class="example">
-      <figcaption><code>ResourceManagementEvent</code> Created JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:264a9afc-c023-43f9-ab15-bdb8b39ab8ae",
-  "type": "ResourceManagementEvent",
-  "actor": {
-    "id": "https://example.edu/users/112233",
-    "type": "Person"
-  },
-  "action": "Created",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-    "type": "QuestionnaireItem",
-    "question": {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/2/question",
-      "type": "OpenEndedQuestion",
-      "questionPosed": "What would you change about your course?"
-    },
-    "categories": ["teaching effectiveness", "Course structure"],
-    "weight": 1.0
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/112233",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Instructor" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
-    </figure>
-  </section>
+    <section class="informative">
+      <h2>Survey</h2>
 
-
-  <section class="informative">
-    <h2>Collection Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>Collection</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/collections/1",
-  "type": "Collection",
-  "items": [
-    {
-      "id": "https://example.edu/videos/1225",
-      "type": "VideoObject",
-      "mediaType": "video/ogg",
-      "name": "Introduction to IMS Caliper",
-      "dateCreated": "2018-08-01T06:00:00.000Z",
-      "duration": "PT1H12M27S",
-      "version": "1.1"
-    },
-    {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/assess/1/items/6/users/554433/responses/1",
-      "type": "Response",
-      "dateCreated": "2018-11-15T10:15:46.000Z",
-      "startedAtTime": "2018-11-15T10:15:46.000Z",
-      "endedAtTime": "2018-11-15T10:17:20.000Z"
-    }
-  ]
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>Survey Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>Survey</code> describe JSON-LD</figcaption>
+      <figure class="example">
+        <figcaption><code>Survey</code> describe JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "https://example.edu/collections/1",
@@ -2646,231 +2590,14 @@
     }
   ]
 }</code></pre>
-    </figure>
-  </section>
+      </figure>
+    </section>
 
-  <section class="informative">
-    <h2>Questionnaire Describe</h2>
+    <section class="informative">
+      <h2>SurveyInvitation</h2>
 
-    <figure class="example">
-      <figcaption><code>Questionnaire</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30",
-  "type": "Questionnaire",
-  "items": [
-    {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-      "type": "QuestionnaireItem"
-    },
-    {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-      "type": "QuestionnaireItem"
-    }
-  ],
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>QuestionnaireItem Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>QuestionnaireItem</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-  "type": "QuestionnaireItem",
-  "question": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
-    "type": "RatingScaleQuestion",
-    "questionPosed": "How satisfied are you with our services?",
-    "scale": {
-      "id": "https://example.edu/scale/2",
-      "type": "LikertScale",
-      "points": 4,
-      "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-      "itemValues": [-2, -1, 1, 2]
-    }
-  },
-  "categories": ["teaching effectiveness", "Course structure"],
-  "weight": 1.0
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>Question Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>Question</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/5/question",
-  "type": "Question",
-  "questionPosed": "What is this generic question about?",
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>RatingScaleQuestion Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>RatingScaleQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
-  "type": "RatingScaleQuestion",
-  "questionPosed": "What is this generic scale question about?",
-  "scale": {
-    "id": "https://example.edu/scale/2",
-    "type": "LikertScale",
-    "points": 4,
-    "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-    "itemValues": [-2, -1, 1, 2]
-  }
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>DateTimeQuestion Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>DateTimeQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/3/question",
-  "type": "DateTimeQuestion",
-  "questionPosed": "When would you be available for an exam next term?",
-  "minDateTime": "2018-09-01T06:00:00.000Z",
-  "minLabel": "Start of Term",
-  "maxDateTime": "2018-12-30T06:00:00.000Z",
-  "maxLabel": "End of Term"
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>MultiselectQuestion Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>MultiselectQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/4/question",
-  "type": "MultiselectQuestion",
-  "questionPosed": "What do you want to study today?",
-  "points": 4,
-  "itemLabels": ["Calculus", "Number theory", "Combinatorics", "Algebra"],
-  "itemValues": [
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/2",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/3",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/4",
-  ],
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>OpenEndedQuestion Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>OpenEndedQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/2/question",
-  "type": "OpenEndedQuestion",
-  "questionPosed": "What would you change about your course?"
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>RatingScaleResponse Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>RatingScaleResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/1/users/554433/responses/1",
-  "type": "RatingScaleResponse",
-  "selections": ["Satisfied"],
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>DateTimeResponse Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>DateTimeResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/4/users/554433/responses/4",
-  "type": "DateTimeResponse",
-  "dateTimeSelected": "2018-12-15T06:00:00.000Z",
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
-    </figure>
-  </section>
-
-  <section class="informative">
-    <h2>MultiselectResponse Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>MultiselectResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/5/users/554433/responses/5",
-  "type": "MultiselectResponse",
-  "selections": [
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/2"
-  ],
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
-    </figure>
-  </section>
-
-
-  <section class="informative">
-    <h2>OpenEndedResponse Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>OpenEndedResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/2/users/554433/responses/2",
-  "type": "OpenEndedResponse",,
-  "value": "I feel that ...",
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
-    </figure>
-  </section>
-
-
-  <section class="informative">
-    <h2>SurveyInvitation Describe</h2>
-
-    <figure class="example">
-      <figcaption><code>SurveyInvitation</code> describe JSON-LD</figcaption>
+      <figure class="example">
+        <figcaption><code>SurveyInvitation</code> describe JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "https://example.edu/surveys/100/invitations/users/112233",
@@ -2887,46 +2614,263 @@
   },
   "dateCreated": "2018-08-01T06:00:00.000Z"
 }</code></pre>
-    </figure>
-  </section>
+      </figure>
+    </section>
 
+    <section class="informative">
+      <h2>Questionnaire</h2>
 
-  <section class="informative">
-    <h2>Scale Describe</h2>
+      <figure class="example">
+        <figcaption><code>Questionnaire</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30",
+  "type": "Questionnaire",
+  "items": [
+    {
+      "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
+      "type": "QuestionnaireItem"
+    },
+    {
+      "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
+      "type": "QuestionnaireItem"
+    }
+  ],
+  "dateCreated": "2018-08-01T06:00:00.000Z"
+}</code></pre>
+      </figure>
+    </section>
 
-    <figure class="example">
-      <figcaption><code>Scale</code> describe JSON-LD</figcaption>
+    <section class="informative">
+      <h2>QuestionnaireItem</h2>
+
+      <figure class="example">
+        <figcaption><code>QuestionnaireItem</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
+  "type": "QuestionnaireItem",
+  "question": {
+    "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
+    "type": "RatingScaleQuestion",
+    "questionPosed": "How satisfied are you with our services?",
+    "scale": {
+      "id": "https://example.edu/scale/2",
+      "type": "LikertScale",
+      "points": 4,
+      "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
+      "itemValues": ["-2", "-1", "1", "2"]
+    }
+  },
+  "categories": ["teaching effectiveness", "Course structure"],
+  "weight": 1.0
+}</code></pre>
+      </figure>
+    </section>
+
+    <section class="informative">
+      <h2>Question</h2>
+
+      <figure class="example">
+        <figcaption><code>Question</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/5/question",
+  "type": "Question",
+  "questionPosed": "What is this generic question about?",
+}</code></pre>
+      </figure>
+
+      <section class="informative">
+        <h2>RatingScaleQuestion</h2>
+
+        <figure class="example">
+          <figcaption><code>RatingScaleQuestion</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
+  "type": "RatingScaleQuestion",
+  "questionPosed": "What is this generic scale question about?",
+  "scale": {
+    "id": "https://example.edu/scale/2",
+    "type": "LikertScale",
+    "points": 4,
+    "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
+    "itemValues": ["-2", "-1", "1", "2"]
+  }
+}</code></pre>
+        </figure>
+      </section>
+
+      <section class="informative">
+        <h2>DateTimeQuestion</h2>
+
+        <figure class="example">
+          <figcaption><code>DateTimeQuestion</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/3/question",
+  "type": "DateTimeQuestion",
+  "questionPosed": "When would you be available for an exam next term?",
+  "minDateTime": "2018-09-01T06:00:00.000Z",
+  "minLabel": "Start of Term",
+  "maxDateTime": "2018-12-30T06:00:00.000Z",
+  "maxLabel": "End of Term"
+}</code></pre>
+        </figure>
+      </section>
+
+      <section class="informative">
+        <h2>MultiselectQuestion</h2>
+
+        <figure class="example">
+          <figcaption><code>MultiselectQuestion</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/4/question",
+  "type": "MultiselectQuestion",
+  "questionPosed": "What do you want to study today?",
+  "points": 4,
+  "itemLabels": ["Calculus", "Number theory", "Combinatorics", "Algebra"],
+  "itemValues": [
+    "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
+    "https://example.edu/terms/201801/courses/7/sections/1/objectives/2",
+    "https://example.edu/terms/201801/courses/7/sections/1/objectives/3",
+    "https://example.edu/terms/201801/courses/7/sections/1/objectives/4",
+  ],
+}</code></pre>
+        </figure>
+      </section>
+
+      <section class="informative">
+        <h2>OpenEndedQuestion</h2>
+
+        <figure class="example">
+          <figcaption><code>OpenEndedQuestion</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/2/question",
+  "type": "OpenEndedQuestion",
+  "questionPosed": "What would you change about your course?"
+}</code></pre>
+        </figure>
+      </section>
+    </section>
+
+    <section class="informative">
+      <h2>Response</h2>
+
+      <section class="informative">
+        <h2>RatingScaleResponse</h2>
+
+        <figure class="example">
+          <figcaption><code>RatingScaleResponse</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/1/users/554433/responses/1",
+  "type": "RatingScaleResponse",
+  "selections": ["Satisfied"],
+  "startedAtTime": "2018-08-01T05:55:48.000Z",
+  "endedAtTime": "2018-08-01T06:00:00.000Z",
+  "duration": "PT4M12S"
+  "dateCreated": "2018-08-01T06:00:00.000Z"
+}</code></pre>
+        </figure>
+      </section>
+
+      <section class="informative">
+        <h2>DateTimeResponse</h2>
+
+        <figure class="example">
+          <figcaption><code>DateTimeResponse</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/4/users/554433/responses/4",
+  "type": "DateTimeResponse",
+  "dateTimeSelected": "2018-12-15T06:00:00.000Z",
+  "startedAtTime": "2018-08-01T05:55:48.000Z",
+  "endedAtTime": "2018-08-01T06:00:00.000Z",
+  "duration": "PT4M12S"
+  "dateCreated": "2018-08-01T06:00:00.000Z"
+}</code></pre>
+        </figure>
+      </section>
+
+      <section class="informative">
+        <h2>MultiselectResponse</h2>
+
+        <figure class="example">
+          <figcaption><code>MultiselectResponse</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/5/users/554433/responses/5",
+  "type": "MultiselectResponse",
+  "selections": [
+    "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
+    "https://example.edu/terms/201801/courses/7/sections/1/objectives/2"
+  ],
+  "startedAtTime": "2018-08-01T05:55:48.000Z",
+  "endedAtTime": "2018-08-01T06:00:00.000Z",
+  "duration": "PT4M12S"
+  "dateCreated": "2018-08-01T06:00:00.000Z"
+}</code></pre>
+        </figure>
+      </section>
+
+      <section class="informative">
+        <h2>OpenEndedResponse</h2>
+
+        <figure class="example">
+          <figcaption><code>OpenEndedResponse</code> describe JSON-LD</figcaption>
+<pre><code>{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
+  "id": "https://example.edu/surveys/100/questionnaires/30/items/2/users/554433/responses/2",
+  "type": "OpenEndedResponse",,
+  "value": "I feel that ...",
+  "startedAtTime": "2018-08-01T05:55:48.000Z",
+  "endedAtTime": "2018-08-01T06:00:00.000Z",
+  "duration": "PT4M12S"
+  "dateCreated": "2018-08-01T06:00:00.000Z"
+}</code></pre>
+        </figure>
+      </section>
+    </section>
+
+    <section class="informative">
+      <h2>Scale</h2>
+
+      <figure class="example">
+        <figcaption><code>Scale</code> describe JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "https://example.edu/scale/1",
   "type": "Scale",
   "dateCreated": "2018-08-01T06:00:00.000Z"
 }</code></pre>
-    </figure>
-  </section>
+      </figure>
 
-  <section class="informative">
-    <h2>LikertScale Describe</h2>
+      <section class="informative">
+        <h2>LikertScale</h2>
 
-    <figure class="example">
-      <figcaption><code>LikertScale</code> describe JSON-LD</figcaption>
+        <figure class="example">
+          <figcaption><code>LikertScale</code> describe JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "https://example.edu/scale/2",
   "type": "LikertScale",
   "points": 4,
   "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-  "itemValues": [-2, -1, 1, 2],
+  "itemValues": ["-2", "-1", "1", "2"],
   "dateCreated": "2018-08-01T06:00:00.000Z"
 }</code></pre>
-    </figure>
-  </section>
+        </figure>
+      </section>
 
-  <section class="informative">
-    <h2>NumericScale Describe</h2>
+      <section class="informative">
+        <h2>NumericScale</h2>
 
-    <figure class="example">
-      <figcaption><code>NumericScale</code> describe JSON-LD</figcaption>
+        <figure class="example">
+          <figcaption><code>NumericScale</code> describe JSON-LD</figcaption>
 <pre><code>{
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
   "id": "https://example.edu/scale/4",
@@ -2938,9 +2882,10 @@
   "step": 0.5,
   "dateCreated": "2018-08-01T06:00:00.000Z"
 }</code></pre>
-    </figure>
+        </figure>
+      </section>
+    </section>
   </section>
-
 </section>
 
 <section class="appendix informative" id="revisionhistory">


### PR DESCRIPTION
This PR tidies up the Caliper JSON-LD Examples section, adding additional sections to better distinguish between types.  The PR also casts `itemValues` values as strings. 