### PR TITLE
Add/update/trim local-biblio.js.

### DIFF
--- a/profiles/feedback/local-biblio.js
+++ b/profiles/feedback/local-biblio.js
@@ -1,70 +1,21 @@
 var _localBiblio = {
-  "CALIPER-11": {
-    title: "Caliper® Analytics Specification 1.1",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Whyte, Anthony",
-      "Haag, Viktor",
-      "Feng, Linda",
-      "Gylling, Markus",
-      "Ashbourne, Matt",
-      "LaMarche, Wes",
-      "Pelaprat, Etienne"
-    ]
-  },
-  "CALIPER-CERT-11": {
-    title: "Caliper Analytics® Sensor Certification Guide 1.1",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-sensor-cert-guide-v1p1/caliper-sensor-cert-guide-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Whyte, Anthony"
-    ]
-  },
-  "CALIPER-IMPL-11": {
-    title: "Caliper Analytics® Implementation Guide 1.1 @@@ TBD URL",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-implementation-guide-v1p1/caliper-implementation-guide-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "@@@, TBD"
-    ]
-  },
   "CALIPER-FEEDBACK-11": {
-    title: "Caliper Analytics® Feedback Profile 1.1",
-    href: "https://www.imsglobal.org/spec/caliper-feedback/v1p1/",
-    publisher: "IMS Global Learning Consortium",
+    "title": "Caliper Analytics® Feedback Profile 1.1",
+    "href": "https://www.imsglobal.org/spec/caliper-feedback/v1p1/",
+    "publisher": "IMS Global Learning Consortium",
     "authors": [
       "Gardener, Andrew",
       "Whyte, Anthony"
     ]
   },
   "CALIPER-FEEDBACK-11-CONTEXT": {
-    title: "Caliper Analytics® Feedback Profile Context 1.1",
-    href: "https://purl.imsglobal.org/spec/caliper-feedback/v1p1/context/",
-    publisher: "IMS Global Learning Consortium"
+    "title": "Caliper Analytics® Feedback Profile Context 1.1 Extension",
+    "href": "https://purl.imsglobal.org/spec/caliper-feedback/v1p1/context/",
+    "publisher": "IMS Global Learning Consortium"
   },
   "CALIPER-FEEDBACK-11-ERRATA": {
-    title: "Caliper Analytics® Feedback Profile 1.1 Errata",
-    href: "https://www.imsglobal.org/spec/caliper-feedback/v1p1/errata/",
-    publisher: "IMS Global Learning Consortium"
-  },
-  "CALIPER-TL-11": {
-    title: "Caliper Analytics® Tool Launch Profile 1.1",
-    href: "https://www.imsglobal.org/spec/caliper-tl/v1p1/",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Gylling, Markus",
-      "Whyte, Anthony"
-    ]
-  },
-  "CALIPER-TL-11-CONTEXT": {
-    title: "Caliper Analytics® Tool Launch Profile Context 1.1",
-    href: "https://purl.imsglobal.org/spec/caliper-tl/v1p1/context/",
-    publisher: "IMS Global Learning Consortium"
-  },
-  "CALIPER-TL-11-ERRATA": {
-    title: "Caliper Analytics® Tool Launch Profile 1.1 Errata",
-    href: "https://www.imsglobal.org/spec/caliper-tl/v1p1/errata/",
-    publisher: "IMS Global Learning Consortium"
+    "title": "Caliper Analytics® Feedback Profile 1.1 Errata",
+    "href": "https://www.imsglobal.org/spec/caliper-feedback/v1p1/errata/",
+    "publisher": "IMS Global Learning Consortium"
   }
 };

--- a/profiles/resource_management/local-biblio.js
+++ b/profiles/resource_management/local-biblio.js
@@ -1,71 +1,21 @@
 var _localBiblio = {
-  "CALIPER-11": {
-    title: "Caliper® Analytics Specification 1.1",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Whyte, Anthony",
-      "Haag, Viktor",
-      "Feng, Linda",
-      "Gylling, Markus",
-      "Ashbourne, Matt",
-      "LaMarche, Wes",
-      "Pelaprat, Etienne"
-    ]
-  },
-  "CALIPER-CERT-11": {
-    title: "Caliper Analytics® Sensor Certification Guide 1.1",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-sensor-cert-guide-v1p1/caliper-sensor-cert-guide-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Whyte, Anthony"
-    ]
-  },
-  "CALIPER-IMPL-11": {
-    title: "Caliper Analytics® Implementation Guide 1.1 @@@ TBD URL",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-implementation-guide-v1p1/caliper-implementation-guide-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "@@@, TBD"
-    ]
-  },
   "CALIPER-RESOURCE-MANAGEMENT-11": {
-    title: "Caliper Analytics® Resource Management Profile 1.1",
-    href: "https://www.imsglobal.org/spec/caliper-resource-management/v1p1/",
-    publisher: "IMS Global Learning Consortium",
+    "title": "Caliper Analytics® Resource Management Profile 1.1",
+    "href": "https://www.imsglobal.org/spec/caliper-resource-management/v1p1/",
+    "publisher": "IMS Global Learning Consortium",
     "authors": [
-      "Whyte, Anthony",
-      "Ashbourne, Matt",
-      "Gardener, Andrew"
+      "Gardener, Andrew",
+      "Whyte, Anthony"
     ]
   },
   "CALIPER-RESOURCE-MANAGEMENT-11-CONTEXT": {
-    title: "Caliper Analytics® Resource Management Profile Context 1.1",
-    href: "https://purl.imsglobal.org/spec/caliper-resource-management/v1p1/context/",
-    publisher: "IMS Global Learning Consortium"
+    "title": "Caliper Analytics® Resource Management Profile Context 1.1 Extension",
+    "href": "https://purl.imsglobal.org/spec/caliper-resource-management/v1p1/context/",
+    "publisher": "IMS Global Learning Consortium"
   },
   "CALIPER-RESOURCE-MANAGEMENT-11-ERRATA": {
-    title: "Caliper Analytics® Resource Management Profile 1.1 Errata",
-    href: "https://www.imsglobal.org/spec/caliper-resource-management/v1p1/errata/",
-    publisher: "IMS Global Learning Consortium"
-  },
-  "CALIPER-TL-11": {
-    title: "Caliper Analytics® Tool Launch Profile 1.1",
-    href: "https://www.imsglobal.org/spec/caliper-tl/v1p1/",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Gylling, Markus",
-      "Whyte, Anthony"
-    ]
-  },
-  "CALIPER-TL-11-CONTEXT": {
-    title: "Caliper Analytics® Tool Launch Profile Context 1.1",
-    href: "https://purl.imsglobal.org/spec/caliper-tl/v1p1/context/",
-    publisher: "IMS Global Learning Consortium"
-  },
-  "CALIPER-TL-11-ERRATA": {
-    title: "Caliper Analytics® Tool Launch Profile 1.1 Errata",
-    href: "https://www.imsglobal.org/spec/caliper-tl/v1p1/errata/",
-    publisher: "IMS Global Learning Consortium"
+    "title": "Caliper Analytics® Resource Management Profile 1.1 Errata",
+    "href": "https://www.imsglobal.org/spec/caliper-resource-management/v1p1/errata/",
+    "publisher": "IMS Global Learning Consortium"
   }
 };

--- a/profiles/search/local-biblio.js
+++ b/profiles/search/local-biblio.js
@@ -1,0 +1,22 @@
+var _localBiblio = {
+  "CALIPER-SEARCH-11": {
+    "title": "Caliper Analytics® Search Profile 1.1",
+    "href": "https://www.imsglobal.org/spec/caliper-search/v1p1/",
+    "publisher": "IMS Global Learning Consortium",
+    "authors": [
+      "Green, Daniel",
+      "Whyte, Anthony",
+      "Gylling, Markus"
+    ]
+  },
+  "CALIPER-SEARCH-11-CONTEXT": {
+    "title": "Caliper Analytics® Search Profile Context 1.1 Extension",
+    "href": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
+    "publisher": "IMS Global Learning Consortium"
+  },
+  "CALIPER-SEARCH-11-ERRATA": {
+    "title": "Caliper Analytics® Search Profile 1.1 Errata",
+    "href": "https://www.imsglobal.org/spec/caliper-search/v1p1/errata/",
+    "publisher": "IMS Global Learning Consortium"
+  },
+};

--- a/profiles/survey/local-biblio.js
+++ b/profiles/survey/local-biblio.js
@@ -1,90 +1,22 @@
 var _localBiblio = {
-  "CALIPER-11": {
-    title: "Caliper® Analytics Specification 1.1",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Whyte, Anthony",
-      "Haag, Viktor",
-      "Feng, Linda",
-      "Gylling, Markus",
-      "Ashbourne, Matt",
-      "LaMarche, Wes",
-      "Pelaprat, Etienne"
-    ]
-  },
-  "CALIPER-CERT-11": {
-    title: "Caliper Analytics® Sensor Certification Guide 1.1",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-sensor-cert-guide-v1p1/caliper-sensor-cert-guide-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Whyte, Anthony"
-    ]
-  },
-  "CALIPER-IMPL-11": {
-    title: "Caliper Analytics® Implementation Guide 1.1 @@@ TBD URL",
-    href: "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-implementation-guide-v1p1/caliper-implementation-guide-v1p1.html",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "@@@, TBD"
-    ]
-  },
-  "CALIPER-SEARCH-11": {
-    title: "Caliper Analytics® Search Profile 1.1",
-    href: "https://www.imsglobal.org/spec/caliper-search/v1p1/",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Green, Daniel",
-      "Whyte, Anthony",
-      "Gylling, Markus"
-    ]
-  },
-  "CALIPER-SEARCH-11-CONTEXT": {
-    title: "Caliper Analytics® Search Profile Context 1.1",
-    href: "https://purl.imsglobal.org/spec/caliper-search/v1p1/context/",
-    publisher: "IMS Global Learning Consortium"
-  },
-  "CALIPER-SEARCH-11-ERRATA": {
-    title: "Caliper Analytics® Search Profile 1.1 Errata",
-    href: "https://www.imsglobal.org/spec/caliper-search/v1p1/errata/",
-    publisher: "IMS Global Learning Consortium"
-  },
   "CALIPER-SURVEY-11": {
-    title: "Caliper Analytics® Survey Profile 1.1",
-    href: "https://www.imsglobal.org/spec/caliper-survey/v1p1/",
-    publisher: "IMS Global Learning Consortium",
+    "title": "Caliper Analytics® Survey Profile 1.1",
+    "href": "https://www.imsglobal.org/spec/caliper-survey/v1p1/",
+    "publisher": "IMS Global Learning Consortium",
     "authors": [
       "Jang, Yeona",
+      "Andrew Gardener",
       "Whyte, Anthony"
     ]
   },
   "CALIPER-SURVEY-11-CONTEXT": {
-    title: "Caliper Analytics® Survey Profile Context 1.1",
-    href: "https://purl.imsglobal.org/spec/caliper-survey/v1p1/context/",
-    publisher: "IMS Global Learning Consortium"
+    "title": "Caliper Analytics® Survey Profile Context 1.1 Extension",
+    "href": "https://purl.imsglobal.org/spec/caliper-survey/v1p1/context/",
+    "publisher": "IMS Global Learning Consortium"
   },
   "CALIPER-SURVEY-11-ERRATA": {
-    title: "Caliper Analytics® Survey Profile 1.1 Errata",
-    href: "https://www.imsglobal.org/spec/caliper-survey/v1p1/errata/",
-    publisher: "IMS Global Learning Consortium"
-  },
-  "CALIPER-TL-11": {
-    title: "Caliper Analytics® Tool Launch Profile 1.1",
-    href: "https://www.imsglobal.org/spec/caliper-tl/v1p1/",
-    publisher: "IMS Global Learning Consortium",
-    "authors": [
-      "Gylling, Markus",
-      "Whyte, Anthony"
-    ]
-  },
-  "CALIPER-TL-11-CONTEXT": {
-    title: "Caliper Analytics® Tool Launch Profile Context 1.1",
-    href: "https://purl.imsglobal.org/spec/caliper-tl/v1p1/context/",
-    publisher: "IMS Global Learning Consortium"
-  },
-  "CALIPER-TL-11-ERRATA": {
-    title: "Caliper Analytics® Tool Launch Profile 1.1 Errata",
-    href: "https://www.imsglobal.org/spec/caliper-tl/v1p1/errata/",
-    publisher: "IMS Global Learning Consortium"
+    "title": "Caliper Analytics® Survey Profile 1.1 Errata",
+    "href": "https://www.imsglobal.org/spec/caliper-survey/v1p1/errata/",
+    "publisher": "IMS Global Learning Consortium"
   }
 };

--- a/profiles/toollaunch/caliper-profile-tool_launch-v1p1.html
+++ b/profiles/toollaunch/caliper-profile-tool_launch-v1p1.html
@@ -15,10 +15,10 @@
             specType: "spec",
             contributors: [
                 {
-                name: "Markus Gylling",
-                company: "IMS Global (Sweden)",
-                companyURL: "www.imsglobal.org",
-                role: "Author"
+                    name: "Markus Gylling",
+                    company: "IMS Global (Sweden)",
+                    companyURL: "www.imsglobal.org",
+                    role: "Author"
                 },
                 {
                     name: "Viktor Haag",

--- a/profiles/toollaunch/local-biblio.js
+++ b/profiles/toollaunch/local-biblio.js
@@ -1,0 +1,22 @@
+var _localBiblio = {
+  "CALIPER-TOOLLAUNCH-11": {
+    "title": "Caliper Analytics® Tool Launch Profile 1.1",
+    "href": "https://www.imsglobal.org/spec/caliper-toollaunch/v1p1/",
+    "publisher": "IMS Global Learning Consortium",
+    "authors": [
+      "Gylling, Markus",
+      "Haag, Viktor",
+      "Whyte, Anthony"
+    ]
+  },
+  "CALIPER-TOOLLAUNCH-11-CONTEXT": {
+    "title": "Caliper Analytics® Tool Launch Profile Context 1.1 Extension",
+    "href": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
+    "publisher": "IMS Global Learning Consortium"
+  },
+  "CALIPER-TOOLLAUNCH-11-ERRATA": {
+    "title": "Caliper Analytics® Tool Launch Profile 1.1 Errata",
+    "href": "https://www.imsglobal.org/spec/caliper-toollaunch/v1p1/errata/",
+    "publisher": "IMS Global Learning Consortium"
+  },
+};

--- a/profiles/tooluse/caliper-profile-tool_use-v1p1.html
+++ b/profiles/tooluse/caliper-profile-tool_use-v1p1.html
@@ -17,19 +17,19 @@
                     name: "Dan Carroll",
                     company: "Clever (USA)",
                     companyURL: "https://www.clever.com/",
-                    role: "Author, Editor"
+                    role: "Author"
                 },
                 {
                     name: "Markus Gylling",
                     company: "IMS Global (Sweden)",
                     companyURL: "https://www.imsglobal.org",
-                    role: "Author, Editor"
+                    role: "Author"
                 },
                 {
                     name: "Anthony Whyte",
                     company: "University of Michigan (USA)",
                     companyURL: "https://umich.edu",
-                    role: "Author, Editor"
+                    role: "Author"
                 }]
         };
     </script>

--- a/profiles/tooluse/local-biblio.js
+++ b/profiles/tooluse/local-biblio.js
@@ -1,0 +1,22 @@
+var _localBiblio = {
+  "CALIPER-TOOLUSE-11": {
+    "title": "Caliper Analytics® Tool Launch Profile 1.1",
+    "href": "https://www.imsglobal.org/spec/caliper-toollaunch/v1p1/",
+    "publisher": "IMS Global Learning Consortium",
+    "authors": [
+      "Dan Carroll",
+      "Gylling, Markus",
+      "Whyte, Anthony"
+    ]
+  },
+  "CALIPER-TOOLUSE-11-CONTEXT": {
+    "title": "Caliper Analytics® Tool Launch Profile Context 1.1 Extension",
+    "href": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
+    "publisher": "IMS Global Learning Consortium"
+  },
+  "CALIPER-TOOLUSE-11-ERRATA": {
+    "title": "Caliper Analytics® Tool Launch Profile 1.1 Errata",
+    "href": "https://www.imsglobal.org/spec/caliper-toollaunch/v1p1/errata/",
+    "publisher": "IMS Global Learning Consortium"
+  },
+};


### PR DESCRIPTION
This PR adds, updates, and trim `local-biblio.js` files associated with the profiles.  An accompanying `spec-central` PR will add missing biblio references to new Caliper profiles.