### PR TITLE
Adding missing profile properties to Event fixtures

### DIFF
--- a/fixtures/v1p2/caliperEventFeedbackCommented.json
+++ b/fixtures/v1p2/caliperEventFeedbackCommented.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369",
   "type": "FeedbackEvent",
+  "profile": "FeedbackProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventFeedbackRanked.json
+++ b/fixtures/v1p2/caliperEventFeedbackRanked.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:a502e4fc-24c1-11e9-ab14-d663bd873d93",
   "type": "FeedbackEvent",
+  "profile": "FeedbackProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventNavigationNavigatedTo.json
+++ b/fixtures/v1p2/caliperEventNavigationNavigatedTo.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:ff9ec22a-fc59-4ae1-ae8d-2c9463ee2f8f",
   "type": "NavigationEvent",
+  "profile": "ReadingProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventNavigationNavigatedToCollectionItem.json
+++ b/fixtures/v1p2/caliperEventNavigationNavigatedToCollectionItem.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:ff9ec22a-fc59-4ae1-ae8d-2c9463ee2f8f",
   "type": "NavigationEvent",
+  "profile": "MediaProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventQuestionnaireItemCompleted.json
+++ b/fixtures/v1p2/caliperEventQuestionnaireItemCompleted.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93",
   "type": "QuestionnaireItemEvent",
+  "profile": "SurveyProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventQuestionnaireItemStarted.json
+++ b/fixtures/v1p2/caliperEventQuestionnaireItemStarted.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93",
   "type": "QuestionnaireItemEvent",
+  "profile": "SurveyProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventQuestionnaireStarted.json
+++ b/fixtures/v1p2/caliperEventQuestionnaireStarted.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93",
   "type": "QuestionnaireEvent",
+  "profile": "SurveyProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventQuestionnaireSubmitted.json
+++ b/fixtures/v1p2/caliperEventQuestionnaireSubmitted.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:79f18ac2-3c6b-11e9-b210-d663bd873d93",
   "type": "QuestionnaireEvent",
+  "profile": "SurveyProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventResourceManagementCopied.json
+++ b/fixtures/v1p2/caliperEventResourceManagementCopied.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:d3543a73-e307-4190-a755-5ce7b3187bc5",
   "type": "ResourceManagementEvent",
+  "profile": "ResourceManagementProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventResourceManagementCreated.json
+++ b/fixtures/v1p2/caliperEventResourceManagementCreated.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369",
   "type": "ResourceManagementEvent",
+  "profile": "ResourceManagementProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventResourceManagementPrinted.json
+++ b/fixtures/v1p2/caliperEventResourceManagementPrinted.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:d3543a73-e307-4190-a755-5ce7b3187bc5",
   "type": "ResourceManagementEvent",
+  "profile": "ResourceManagementProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventSearchSearched.json
+++ b/fixtures/v1p2/caliperEventSearchSearched.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:cb3878ed-8240-4c6d-9fee-77221810f5e4",
   "type": "SearchEvent",
+  "profile": "SearchProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventSurveyInvitationAccepted.json
+++ b/fixtures/v1p2/caliperEventSurveyInvitationAccepted.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:534afa10-3564-11e9-b210-d663bd873d93",
   "type": "SurveyInvitationEvent",
+  "profile": "SurveyProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventSurveyInvitationSent.json
+++ b/fixtures/v1p2/caliperEventSurveyInvitationSent.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:5801f73e-3564-11e9-b210-d663bd873d93",
   "type": "SurveyInvitationEvent",
+  "profile": "SurveyProfile",
   "actor": {
     "id": "https://example.edu/users/112233",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventSurveyOptedIn.json
+++ b/fixtures/v1p2/caliperEventSurveyOptedIn.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:4bfb7726-3564-11e9-b210-d663bd873d93",
   "type": "SurveyEvent",
+  "profile": "SurveyProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/fixtures/v1p2/caliperEventToolLaunchReturned.json
+++ b/fixtures/v1p2/caliperEventToolLaunchReturned.json
@@ -1,57 +1,58 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
-    "id": "urn:uuid:a2e8b214-4d4a-4456-bb4c-099945749117",
-    "type": "ToolLaunchEvent",
-    "actor": {
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
+  "id": "urn:uuid:a2e8b214-4d4a-4456-bb4c-099945749117",
+  "type": "ToolLaunchEvent",
+  "profile": "ToolLaunchProfile",
+  "actor": {
+    "id": "https://example.edu/users/554433",
+    "type": "Person"
+  },
+  "action": "Returned",
+  "object": {
+    "id": "https://example.com/lti/tool",
+    "type": "SoftwareApplication"
+  },
+  "eventTime": "2018-11-15T10:15:00.000Z",
+  "edApp": {
+    "id": "https://example.edu",
+    "type": "SoftwareApplication"
+  },
+  "referrer": {
+    "id": "https://tool.com/lti/123",
+    "type": "LtiLink"
+  },
+  "group": {
+    "id": "https://example.edu/terms/201801/courses/7/sections/1",
+    "type": "CourseSection",
+    "courseNumber": "CPS 435-01",
+    "academicSession": "Fall 2018"
+  },
+  "membership": {
+    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
+    "type": "Membership",
+    "member": "https://example.edu/users/554433",
+    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
+    "roles": [ "Learner" ],
+    "status": "Active",
+    "dateCreated": "2018-08-01T06:00:00.000Z"
+  },
+  "session": {
+    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
+    "type": "Session",
+    "startedAtTime": "2018-11-15T10:00:00.000Z"
+  },
+  "target": {
+    "id": "https://example.edu/terms/201801/courses/7/sections/1/pages/1",
+    "type": "Link"
+  },
+  "federatedSession": {
+    "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
+    "type": "LtiSession",
+    "user": {
       "id": "https://example.edu/users/554433",
       "type": "Person"
     },
-    "action": "Returned",
-    "object": {
-      "id": "https://example.com/lti/tool",
-      "type": "SoftwareApplication"
-    },
-    "eventTime": "2018-11-15T10:15:00.000Z",
-    "edApp": {
-      "id": "https://example.edu",
-      "type": "SoftwareApplication"
-    },
-    "referrer": {
-      "id": "https://tool.com/lti/123",
-      "type": "LtiLink"
-    },
-    "group": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1",
-      "type": "CourseSection",
-      "courseNumber": "CPS 435-01",
-      "academicSession": "Fall 2018"
-    },
-    "membership": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-      "type": "Membership",
-      "member": "https://example.edu/users/554433",
-      "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-      "roles": [ "Learner" ],
-      "status": "Active",
-      "dateCreated": "2018-08-01T06:00:00.000Z"
-    },
-    "session": {
-      "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-      "type": "Session",
-      "startedAtTime": "2018-11-15T10:00:00.000Z"
-    },
-    "target": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/pages/1",
-      "type": "Link"
-    },
-    "federatedSession": {
-      "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
-      "type": "LtiSession",
-      "user": {
-        "id": "https://example.edu/users/554433",
-        "type": "Person"
-      },
-      "dateCreated": "2018-11-15T10:15:00.000Z",
-      "startedAtTime": "2018-11-15T10:15:00.000Z"
-    }
+    "dateCreated": "2018-11-15T10:15:00.000Z",
+    "startedAtTime": "2018-11-15T10:15:00.000Z"
+  }
 }

--- a/fixtures/v1p2/caliperEventToolUseUsedWithProgress.json
+++ b/fixtures/v1p2/caliperEventToolUseUsedWithProgress.json
@@ -2,6 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d916",
   "type": "ToolUseEvent",
+  "profile": "ToolUseProfile",
   "actor": {
     "id": "https://example.edu/users/554433",
     "type": "Person"


### PR DESCRIPTION
This PR adds profile properties to 17 fixture files within fixtures/v1p2. In addition, the indentation on one file (`caliperEventToolLaunchReturned.json`) was changed to be consistent with the formatting of other fixtures. 