### PR TITLE
Add ToolUseEvent fixture featuring anonymous entities and Session with client fixture

### DIFF
--- a/fixtures/v1p2/caliperEntitySessionClient.json
+++ b/fixtures/v1p2/caliperEntitySessionClient.json
@@ -1,0 +1,17 @@
+{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
+  "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
+  "type": "Session",
+  "user": {
+    "id": "https://example.edu/users/554433",
+    "type": "Person"
+  },
+  "client": {
+    "id": "urn:uuid:d71016dc-ed2f-46f9-ac2c-b93f15f38fdc",
+    "type": "SoftwareApplication",
+    "host": "https://example.edu",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36",
+    "ipAddress": "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+  },
+  "startedAtTime": "2018-09-15T10:00:00.000Z"
+}

--- a/fixtures/v1p2/caliperEventToolUseUsedAnonymous.json
+++ b/fixtures/v1p2/caliperEventToolUseUsedAnonymous.json
@@ -1,0 +1,35 @@
+{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
+  "id": "urn:uuid:7c0fc54b-cf2a-426f-9203-b2c97fb77bfd",
+  "type": "ToolUseEvent",
+  "profile": "ToolUseProfile",
+  "actor": {
+    "id": "http://purl.imsglobal.org/caliper/Person",
+    "type": "Person"
+  },
+  "action": "Used",
+  "object": {
+    "id": "https://example.edu",
+    "type": "SoftwareApplication"
+  },
+  "eventTime": "2018-11-15T10:15:00.000Z",
+  "edApp": "https://example.edu",
+  "group": {
+    "id": "http://purl.imsglobal.org/caliper/CourseSection",
+    "type": "CourseSection"
+  },
+  "membership": {
+    "id": "http://purl.imsglobal.org/caliper/Membership",
+    "type": "Membership",
+    "member": {
+      "id": "http://purl.imsglobal.org/caliper/Person",
+      "type": "Person"
+    },
+    "organization": {
+      "id": "http://purl.imsglobal.org/caliper/CourseSection",
+      "type": "CourseSection"
+    },
+    "roles": [ "Learner" ],
+    "status": "Active"
+  }
+}


### PR DESCRIPTION
This PR adds two v1p2 fixtures that align with v1p2 spec doc additions:
1. `caliperEventToolUseUsedAnonymous.json` featuring multiple anonymous entities.  Required to match example 2 wording in the new v1p2 Anonymous Entities section of the spec.
2. `caliperEntitySessionClient.json` featuring `client` reference to a browser-based `SoftwareApplication`.