### PR TITLE
add SystemIdentifier fixture

### DIFF
--- a/fixtures/v1p2/caliperIdentifierSystemIdentifier.json
+++ b/fixtures/v1p2/caliperIdentifierSystemIdentifier.json
@@ -1,0 +1,9 @@
+{
+  "type": "SystemIdentifier",
+  "identifier": "https://example.edu/users/554433",
+  "identifierType": "LtiUserId",
+  "source":  {
+    "id": "https://example.edu",
+    "type": "SoftwareApplication"
+  }
+}


### PR DESCRIPTION
This PR adds an `SystemIdentifier` fixture that is used as an example in the v1p2 spec.