### PR TITLE
Pull profile JSON-LD examples from fixtures/ directory

### DIFF
--- a/profiles/feedback/caliper-profile-feedback-v1p1.html
+++ b/profiles/feedback/caliper-profile-feedback-v1p1.html
@@ -179,89 +179,16 @@
         <section class="informative">
             <h3>FeedbackEvent</h3>
 
-        <section class="informative">
-            <h3>Commented</h3>
+            <section class="informative">
+                <h3>Commented</h3>
 
-            <p>Below is an example of a Caliper <a href="#FeedbackEvent">FeedbackEvent</a> that records a
-                <code>Person</code> providing informal feedback in the form of a <a href="#Comment">Comment</a>.
-            </p>
+                <p>Below is an example of a Caliper <a href="#FeedbackEvent">FeedbackEvent</a> that records a
+                    <code>Person</code> providing informal feedback in the form of a <a href="#Comment">Comment</a>.
+                </p>
 
-            <figure class="example">
-                <figcaption><code>FeedbackEvent</code> Commented JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369",
-  "type": "FeedbackEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Commented",
-  "object": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-    "type": "DigitalResource",
-    "name": "Course Syllabus",
-    "mediaType": "application/pdf",
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-      "type": "DigitalResourceCollection",
-      "name": "Course Assets",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1",
-        "type": "CourseSection"
-      }
-    },
-    "dateCreated": "2018-08-02T11:32:00.000Z"
-  },
-  "generated": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/assess/1/items/6/users/665544/responses/1/comment/1",
-    "type": "Comment",
-    "commenter": {
-      "id": "https://example.edu/users/554433",
-      "type": "Person"
-    },
-    "commentedOn": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-      "type": "DigitalResource",
-      "name": "Course Syllabus",
-      "mediaType": "application/pdf",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-        "type": "DigitalResourceCollection",
-        "name": "Course Assets",
-        "isPartOf": {
-          "id": "https://example.edu/terms/201801/courses/7/sections/1",
-          "type": "CourseSection"
-        }
-      },
-      "dateCreated": "2018-08-02T11:32:00.000Z"
-    },
-    "value": "I like what you did here but you need to improve on...",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-15T10:05:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  }
-}</code></pre>
+                <figure class="example">
+                    <figcaption><code>FeedbackEvent</code> Commented JSON-LD</figcaption>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventFeedbackCommented.json"></code></pre>
                 </figure>
             </section>
 
@@ -274,118 +201,7 @@
 
                 <figure class="example">
                     <figcaption><code>FeedbackEvent</code> Ranked JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "urn:uuid:a502e4fc-24c1-11e9-ab14-d663bd873d93",
-  "type": "FeedbackEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Ranked",
-  "object": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-    "type": "DigitalResource",
-    "name": "Course Syllabus",
-    "mediaType": "application/pdf",
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-      "type": "DigitalResourceCollection",
-      "name": "Course Assets",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1",
-        "type": "CourseSection"
-      }
-    },
-    "dateCreated": "2018-08-02T11:32:00.000Z"
-  },
-  "generated": {
-    "id": "https://example.edu/users/554433/rating/1",
-    "type": "Rating",
-    "rater": {
-      "id": "https://example.edu/users/554433",
-      "type": "Person"
-    },
-    "rated": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-      "type": "DigitalResource",
-      "name": "Course Syllabus",
-      "mediaType": "application/pdf",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-        "type": "DigitalResourceCollection",
-        "name": "Course Assets",
-        "isPartOf": {
-          "id": "https://example.edu/terms/201801/courses/7/sections/1",
-          "type": "CourseSection"
-        }
-      },
-      "dateCreated": "2018-08-02T11:32:00.000Z"
-    },
-    "question": {
-      "id": "https://example.edu/question/2",
-      "type": "RatingScaleQuestion",
-      "questionPosed": "Do you agree with the opinion presented?",
-      "scale": {
-        "id": "https://example.edu/scale/2",
-        "type": "LikertScale",
-        "scalePoints": 4,
-        "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-        "itemValues": ["-2", "-1", "1", "2"]
-      }
-    },
-    "selections": ["1"],
-    "ratingComment": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/assess/1/items/6/users/665544/responses/1/comment/1",
-      "type": "Comment",
-      "commenter": {
-        "id": "https://example.edu/users/554433",
-        "type": "Person"
-      },
-      "commentedOn": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-        "type": "DigitalResource",
-        "name": "Course Syllabus",
-        "mediaType": "application/pdf",
-        "isPartOf": {
-          "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-          "type": "DigitalResourceCollection",
-          "name": "Course Assets",
-          "isPartOf": {
-            "id": "https://example.edu/terms/201801/courses/7/sections/1",
-            "type": "CourseSection"
-          }
-        },
-        "dateCreated": "2018-08-02T11:32:00.000Z"
-      },
-      "value": "I like what you did here but you need to improve on...",
-      "dateCreated": "2018-08-01T06:00:00.000Z"
-    },
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-15T10:05:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  }
-}</code></pre>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventFeedbackRanked.json"></code></pre>
                 </figure>
             </section>
         </section>
@@ -394,42 +210,16 @@
     <section class="informative">
         <h2>Entity Describes</h2>
 
-            <section class="informative">
-                <h3>Comment</h3>
+        <section class="informative">
+            <h3>Comment</h3>
 
-                <p>Below is an example of a <a href="#Comment">Comment</a> entity describe that can also be sent to an
-                    endpoint. The <a href="#Comment">Comment</a> references the commenter, the resource commented on,
-                    and a the comment text value.</p>
+            <p>Below is an example of a <a href="#Comment">Comment</a> entity describe that can also be sent to an
+                endpoint. The <a href="#Comment">Comment</a> references the commenter, the resource commented on,
+                and the comment text value.</p>
 
-                <figure class="example">
-                    <figcaption><code>Comment</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/terms/201801/courses/7/sections/1/assess/1/items/6/users/665544/responses/1/comment/1",
-  "type": "Comment",
-  "commenter": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "commentedOn": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-    "type": "DigitalResource",
-    "name": "Course Syllabus",
-    "mediaType": "application/pdf",
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-      "type": "DigitalResourceCollection",
-      "name": "Course Assets",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1",
-        "type": "CourseSection"
-      }
-    },
-    "dateCreated": "2018-08-02T11:32:00.000Z"
-  },
-  "value": "I like what you did here but you need to improve on...",
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+            <figure class="example">
+                <figcaption><code>Comment</code> describe JSON-LD</figcaption>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityComment.json"></code></pre>
             </figure>
         </section>
 
@@ -442,12 +232,7 @@
 
             <figure class="example">
                 <figcaption><code>Question</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/question/1",
-  "type": "Question",
-  "questionPosed": "How would you rate this?"
-}</code></pre>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityQuestion.json"></code></pre>
             </figure>
 
             <section class="informative">
@@ -455,20 +240,7 @@
 
                 <figure class="example">
                     <figcaption><code>RatingScaleQuestion</code> describe JSON-LD</figcaption>
-    <pre><code>{
-      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-      "id": "https://example.edu/question/2",
-      "type": "RatingScaleQuestion",
-      "questionPosed": "Do you agree with the opinion presented?",
-      "scale": {
-        "id": "https://example.edu/scale/2",
-        "type": "LikertScale",
-        "scalePoints": 4,
-        "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-        "itemValues": ["-2", "-1", "1", "2"],
-        "dateCreated": "2018-08-01T06:00:00.000Z"
-      }
-    }</code></pre>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEntityRatingScaleQuestion.json"></code></pre>
                 </figure>
             </section>
         </section>
@@ -482,119 +254,20 @@
 
             <figure class="example">
                 <figcaption>Likert Scale <code>Rating</code> describe JSON-LD</figcaption>
-                <pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/users/554433/rating/1",
-  "type": "Rating",
-  "rater": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "rated": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-    "type": "DigitalResource",
-    "name": "Course Syllabus",
-    "mediaType": "application/pdf",
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-      "type": "DigitalResourceCollection",
-      "name": "Course Assets",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1",
-        "type": "CourseSection"
-      }
-    },
-    "dateCreated": "2018-08-02T11:32:00.000Z"
-  },
-  "question": {
-    "id": "https://example.edu/question/2",
-    "type": "RatingScaleQuestion",
-    "questionPosed": "Do you agree with the opinion presented?",
-    "scale": {
-      "id": "https://example.edu/scale/2",
-      "type": "LikertScale",
-      "scalePoints": 4,
-      "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-      "itemValues": ["-2", "-1", "1", "2"]
-    }
-  },
-  "selections": ["1"],
-  "ratingComment": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/assess/1/items/6/users/665544/responses/1/comment/1",
-    "type": "Comment",
-    "commenter": {
-      "id": "https://example.edu/users/554433",
-      "type": "Person"
-    },
-    "commentedOn": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-      "type": "DigitalResource",
-      "name": "Course Syllabus",
-      "mediaType": "application/pdf",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-        "type": "DigitalResourceCollection",
-        "name": "Course Assets",
-        "isPartOf": {
-          "id": "https://example.edu/terms/201801/courses/7/sections/1",
-          "type": "CourseSection"
-        }
-      },
-      "dateCreated": "2018-08-02T11:32:00.000Z"
-    },
-    "value": "I like what you did here but you need to improve on...",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityRatingWithLikertScale.json"></code></pre>
             </figure>
         </section>
 
         <section class="informative">
-
             <h3>Rating (Multiselect)</h3>
 
-            <p>Below is an example of a multi-select <a href="#Rating">Rating</a> entity describe that can also be sent to an
-                endpoint. The <a href="#Rating">Rating</a> references the rater, the resource rated, the
+            <p>Below is an example of a multi-select <a href="#Rating">Rating</a> entity describe that can also be sent
+                to an endpoint. The <a href="#Rating">Rating</a> references the rater, the resource rated, the
                 scale question employed, the option selected, and a free-form comment.</p>
 
             <figure class="example">
                 <figcaption>Multi-Select <code>Rating</code> describe JSON-LD</figcaption>
-                <pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/users/554433/rating/2",
-  "type": "Rating",
-  "rater": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "rated": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-    "type": "DigitalResourceCollection",
-    "name": "Course Assets",
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1",
-      "type": "CourseSection"
-    }
-  },
-  "question": {
-    "id": "https://example.edu/question/3",
-    "type": "RatingScaleQuestion",
-    "questionPosed": "How do you feel about this content? (select one or more)",
-    "scale": {
-      "id": "https://example.edu/scale/3",
-      "type": "MultiselectScale",
-      "scalePoints": 5,
-      "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
-      "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
-      "isOrderedSelection": false,
-      "minSelections": 1,
-      "maxSelections": 5
-    }
-  },
-  "selections": ["superhappy", "disappointed"],
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityRatingWithMultiselectScale.json"></code></pre>
             </figure>
         </section>
 
@@ -606,12 +279,7 @@
 
             <figure class="example">
                 <figcaption><code>Scale</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/scale/1",
-  "type": "Scale",
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityScale.json"></code></pre>
             </figure>
 
             <section class="informative">
@@ -623,14 +291,7 @@
 
                 <figure class="example">
                     <figcaption><code>LikertScale</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/scale/2",
-  "type": "LikertScale",
-  "scalePoints": 4,
-  "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-  "itemValues": ["-2", "-1", "1", "2"]
-}</code></pre>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEntityLikertScale.json"></code></pre>
                 </figure>
             </section>
 
@@ -644,18 +305,7 @@
 
                 <figure class="example">
                     <figcaption><code>MultiselectScale</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/scale/3",
-  "type": "MultiselectScale",
-  "scalePoints": 5,
-  "itemLabels": ["😁", "😀", "😐", "😕", "😞"],
-  "itemValues": ["superhappy", "happy", "indifferent", "unhappy", "disappointed"],
-  "isOrderedSelection": false,
-  "minSelections": 1,
-  "maxSelections": 5,
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEntityMultiselectScale.json"></code></pre>
                 </figure>
             </section>
 
@@ -668,17 +318,7 @@
 
                 <figure class="example">
                     <figcaption><code>NumericScale</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/FeedbackProfile-extension",
-  "id": "https://example.edu/scale/4",
-  "type": "NumericScale",
-  "minValue": 0.0,
-  "minLabel": "Disliked",
-  "maxValue": 10.0,
-  "maxLabel": "Liked",
-  "step": 0.5,
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEntityNumericScale.json"></code></pre>
                 </figure>
             </section>
         </section>

--- a/profiles/resource_management/caliper-profile-resource_management-v1p1.html
+++ b/profiles/resource_management/caliper-profile-resource_management-v1p1.html
@@ -190,68 +190,15 @@
         <section class="informative">
             <h3>ResourceManagementEvent</h3>
 
-        <section class="informative">
-            <h3>Created</h3>
+            <section class="informative">
+                <h3>Created</h3>
 
-            <p>Below is an example of a Caliper <a href="#event-resourceManagement">ResourceManagementEvent</a> that
-                records a <code>Person</code> creating a <code>DigitalResource</code>.</p>
+                <p>Below is an example of a Caliper <a href="#event-resourceManagement">ResourceManagementEvent</a> that
+                    records a <code>Person</code> creating a <code>DigitalResource</code>.</p>
 
-            <figure class="example">
-                <figcaption><code>ResourceManagementEvent</code> Created JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ResourceManagementProfile-extension",
-  "id": "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369",
-  "type": "ResourceManagementEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Created",
-  "object": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-    "type": "DigitalResource",
-    "name": "Course Syllabus",
-    "mediaType": "application/pdf",
-    "creators": [
-      {
-        "id": "https://example.edu/users/554433",
-        "type": "Person"
-      }
-    ],
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-      "type": "DigitalResourceCollection",
-      "name": "Course Assets",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1",
-        "type": "CourseSection"
-      }
-    },
-    "dateCreated": "2018-08-02T11:32:00.000Z"
-  },
-  "eventTime": "2018-11-15T10:05:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201601/courses/7/sections/1",
-    "roles": [ "Instructor" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  }
-}</code></pre>
+                <figure class="example">
+                    <figcaption><code>ResourceManagementEvent</code> Created JSON-LD</figcaption>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventResourceManagementCreated.json"></code></pre>
                 </figure>
             </section>
 
@@ -261,84 +208,9 @@
                 <p>Below is an example of a Caliper <a href="#event-resourceManagement">ResourceManagementEvent</a> that
                     records a <code>Person</code> generating a new copy of a <code>DigitalResource</code>.
 
-                    <figure class="example">
-                        <figcaption><code>ResourceManagementEvent</code> Copied JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ResourceManagementProfile-extension",
-  "id": "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369",
-  "type": "ResourceManagementEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Copied",
-  "object": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus.pdf",
-    "type": "DigitalResource",
-    "name": "Course Syllabus",
-    "mediaType": "application/pdf",
-    "creators": [
-      {
-        "id": "https://example.edu/users/554433",
-        "type": "Person"
-      }
-    ],
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-      "type": "DigitalResourceCollection",
-      "name": "Course Assets",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1",
-        "type": "CourseSection"
-      }
-    },
-    "dateCreated": "2018-08-02T11:32:00.000Z"
-  },
-  "generated": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/2/syllabus_copy.pdf",
-    "type": "DigitalResource",
-    "name": "Course Syllabus (copy)",
-    "mediaType": "application/pdf",
-    "creators": [
-      {
-        "id": "https://example.edu/users/554433",
-        "type": "Person"
-      }
-    ],
-    "isPartOf": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1",
-      "type": "DigitalResourceCollection",
-      "name": "Course Assets",
-      "isPartOf": {
-        "id": "https://example.edu/terms/201801/courses/7/sections/1",
-        "type": "CourseSection"
-      }
-    },
-    "dateCreated": "2018-11-15T10:05:00.000Z"
-  },
-  "eventTime": "2018-11-15T10:05:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201601/courses/7/sections/1",
-    "roles": [ "Instructor" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  }
-}</code></pre>
+                <figure class="example">
+                    <figcaption><code>ResourceManagementEvent</code> Copied JSON-LD</figcaption>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventResourceManagementCopied.json"></code></pre>
                 </figure>
             </section>
         </section>

--- a/profiles/search/caliper-profile-search-v1p1.html
+++ b/profiles/search/caliper-profile-search-v1p1.html
@@ -190,63 +190,7 @@
 
                 <figure class="example">
                     <figcaption><code>SearchEvent</code> JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
-  "id": "urn:uuid:cb3878ed-8240-4c6d-9fee-77221810f5e4",
-  "type": "SearchEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Searched",
-  "object": {
-    "id": "https://example.edu/catalog",
-    "type": "SoftwareApplication"
-  },
-  "eventTime": "2018-11-15T10:05:00.000Z",
-  "generated": {
-    "id": "https://example.edu/users/554433/search?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-    "type": "SearchResponse",
-    "searchProvider": "https://example.edu",
-    "searchTarget": "https://example.edu/catalog",
-    "query": {
-      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
-      "id": "https://example.edu/users/554433/search?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "type": "Query",
-      "creator": "https://example.edu/users/554433",
-      "searchTarget": "https://example.edu/catalog",
-      "searchTerms": "IMS AND (Caliper OR Analytics)",
-      "dateCreated": "2018-11-15T10:05:00.000Z"
-    },
-    "searchResultsItemCount": 3,
-    "searchResults": [
-      "https://example.edu/catalog/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"
-    ]
-  },
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201601/courses/7/sections/1",
-    "roles": ["Learner"],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  }
-}</code></pre>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventSearchSearched.json"></code></pre>
                 </figure>
             </section>
         </section>
@@ -264,21 +208,7 @@
 
             <figure class="example">
                 <figcaption><code>Query</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
-  "id": "https://example.edu/users/554433/search?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-  "type": "Query",
-  "creator": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "searchTarget": {
-    "id": "https://example.edu/catalog",
-    "type": "SoftwareApplication"
-  },
-  "searchTerms": "IMS AND (Caliper OR Analytics)",
-  "dateCreated": "2018-11-15T10:05:00.000Z"
-}</code></pre>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityQuery.json"></code></pre>
             </figure>
         </section>
 

--- a/profiles/survey/caliper-profile-survey-v1p1.html
+++ b/profiles/survey/caliper-profile-survey-v1p1.html
@@ -285,42 +285,7 @@
 
         <figure class="example">
           <figcaption><code>SurveyEvent</code> OptedIn JSON-LD</figcaption>
-  <pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:4bfb7726-3564-11e9-b210-d663bd873d93",
-  "type": "SurveyEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "OptedIn",
-  "object": {
-    "id": "https://example.edu/survey/1",
-    "type": "Survey"
-  },
-  "eventTime": "2018-11-15T10:05:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventSurveyOptedIn.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -333,53 +298,7 @@
 
         <figure class="example">
           <figcaption><code>SurveyInvitationEvent</code> Accepted JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:534afa10-3564-11e9-b210-d663bd873d93",
-  "type": "SurveyInvitationEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Accepted",
-  "object": {
-    "id": "https://example.edu/surveys/100/invitations/users/112233",
-    "type": "SurveyInvitation",
-    "sentCount": 1,
-    "sentDate": "2018-11-15T10:05:00.000Z",
-    "rater": {
-      "id": "https://example.edu/users/112233",
-      "type": "Person"
-    },
-    "survey": {
-      "id": "https://example.edu/survey/1",
-      "type": "Survey"
-    },
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-15T10:05:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventSurveyInvitationAccepted.json"></code></pre>
         </figure>
       </section>
 
@@ -388,53 +307,7 @@
 
         <figure class="example">
           <figcaption><code>SurveyInvitationEvent</code> Sent JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:5801f73e-3564-11e9-b210-d663bd873d93",
-  "type": "SurveyInvitationEvent",
-  "actor": {
-    "id": "https://example.edu/users/112233",
-    "type": "Person"
-  },
-  "action": "Sent",
-  "object": {
-    "id": "https://example.edu/surveys/100/invitations/users/554433",
-    "type": "SurveyInvitation",
-    "sentCount": 1,
-    "sentDate": "2018-11-15T10:05:00.000Z",
-    "rater": {
-      "id": "https://example.edu/users/554433",
-      "type": "Person"
-    },
-    "survey": {
-      "id": "https://example.edu/survey/1",
-      "type": "Survey"
-    },
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/112233",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Instructor" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventSurveyInvitationSent.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -445,55 +318,9 @@
       <section class="informative">
         <h3>Started</h3>
 
-      <figure class="example">
-        <figcaption><code>QuestionnaireEvent</code> Started JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93",
-  "type": "QuestionnaireEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Started",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30",
-    "type": "Questionnaire",
-    "items": [
-      {
-        "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-        "type": "QuestionnaireItem"
-      },
-      {
-        "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-        "type": "QuestionnaireItem"
-      }
-    ],
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+        <figure class="example">
+          <figcaption><code>QuestionnaireEvent</code> Started JSON-LD</figcaption>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventQuestionnaireStarted.json"></code></pre>
         </figure>
       </section>
 
@@ -502,53 +329,7 @@
 
         <figure class="example">
           <figcaption><code>QuestionnaireEvent</code> Completed JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:79f18ac2-3c6b-11e9-b210-d663bd873d93",
-  "type": "QuestionnaireEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Completed",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30",
-    "type": "Questionnaire",
-    "items": [
-      {
-        "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-        "type": "QuestionnaireItem"
-      },
-      {
-        "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-        "type": "QuestionnaireItem"
-      }
-    ],
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventQuestionnaireCompleted.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -561,56 +342,7 @@
 
         <figure class="example">
           <figcaption><code>QuestionnaireItemEvent</code> Started JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93",
-  "type": "QuestionnaireItemEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Started",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-    "type": "QuestionnaireItem",
-    "question": {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
-      "type": "RatingScaleQuestion",
-      "questionPosed": "How satisfied are you with our services?",
-      "scale": {
-        "id": "https://example.edu/scale/2",
-        "type": "LikertScale",
-        "points": 4,
-        "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-        "itemValues": ["-2", "-1", "1", "2"]
-      }
-    },
-    "categories": ["teaching effectiveness", "Course structure"],
-    "weight": 1.0
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventQuestionnaireItemStarted.json"></code></pre>
         </figure>
       </section>
 
@@ -619,58 +351,7 @@
 
         <figure class="example">
           <figcaption><code>QuestionnaireItemEvent</code> Completed JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93",
-  "type": "QuestionnaireItemEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Completed",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-    "type": "QuestionnaireItem",
-    "question": {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/2/question",
-      "type": "OpenEndedQuestion",
-      "questionPosed": "What would you change about your course?"
-    },
-    "categories": ["teaching effectiveness", "Course structure"],
-    "weight": 1.0
-  },
-  "generated": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/2/users/554433/responses/2",
-    "type": "OpenEndedResponse",
-    "value": "I feel that ...",
-    "startedAtTime": "2018-08-01T05:55:48.000Z",
-    "endedAtTime": "2018-08-01T06:00:00.000Z",
-    "duration": "PT4M12S"
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventQuestionnaireItemCompletedOpenEndedQuestion.json"></code></pre>
         </figure>
       </section>
 
@@ -679,65 +360,7 @@
 
         <figure class="example">
           <figcaption><code>QuestionnaireItemEvent</code> Completed JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93",
-  "type": "QuestionnaireItemEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Completed",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-    "type": "QuestionnaireItem",
-    "question": {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
-      "type": "RatingScaleQuestion",
-      "questionPosed": "How satisfied are you with our services?",
-      "scale": {
-        "id": "https://example.edu/scale/2",
-        "type": "LikertScale",
-        "points": 4,
-        "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-        "itemValues": ["-2", "-1", "1", "2"]
-      }
-    },
-    "categories": ["teaching effectiveness", "Course structure"],
-    "weight": 1.0
-  },
-  "generated": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/1/users/554433/responses/1",
-    "type": "RatingScaleResponse",
-    "selections": ["Satisfied"],
-    "startedAtTime": "2018-08-01T05:55:48.000Z",
-    "endedAtTime": "2018-08-01T06:00:00.000Z",
-    "duration": "PT4M12S"
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventQuestionnaireItemCompletedRatingScaleQuestion.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -750,49 +373,7 @@
 
         <figure class="example">
           <figcaption><code>NavigationEvent</code> NavigatedTo JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:a9ea1cb9-3445-4f5a-b5e5-44630cc054a9",
-  "type": "NavigationEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "NavigatedTo",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-    "type": "QuestionnaireItem",
-    "question": {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/2/question",
-      "type": "OpenEndedQuestion",
-      "questionPosed": "What would you change about your course?"
-    },
-    "categories": ["teaching effectiveness", "Course structure"],
-    "weight": 1.0
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventNavigationNavigatedToQuestionnaireItem.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -805,49 +386,7 @@
 
         <figure class="example">
           <figcaption><code>ViewEvent</code> Viewed JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "urn:uuid:bc780773-ee1e-49f6-ab2b-fe16eb391dd8",
-  "type": "ViewEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Viewed",
-  "object": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-    "type": "QuestionnaireItem",
-    "question": {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/2/question",
-      "type": "OpenEndedQuestion",
-      "questionPosed": "What would you change about your course?"
-    },
-    "categories": ["teaching effectiveness", "Course structure"],
-    "weight": 1.0
-  },
-  "eventTime": "2018-11-12T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/f095bbd391ea4a5dd639724a40b606e98a631823",
-    "type": "Session",
-    "startedAtTime": "2018-11-12T10:00:00.000Z"
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEventViewViewedQuestionnaireItem.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -861,43 +400,7 @@
 
       <figure class="example">
         <figcaption><code>Survey</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/collections/1",
-  "type": "Survey",
-  "items": [
-    {
-      "id": "https://example.edu/surveys/100/questionnaires/30",
-      "type": "Questionnaire",
-      "items": [
-        {
-          "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-          "type": "QuestionnaireItem"
-        },
-        {
-          "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-          "type": "QuestionnaireItem"
-        }
-      ],
-      "dateCreated": "2018-08-01T06:00:00.000Z"
-    },
-    {
-      "id": "https://example.edu/surveys/100/questionnaires/31",
-      "type": "Questionnaire",
-      "items": [
-        {
-          "id": "https://example.edu/surveys/100/questionnaires/31/items/1",
-          "type": "QuestionnaireItem"
-        },
-        {
-          "id": "https://example.edu/surveys/100/questionnaires/31/items/2",
-          "type": "QuestionnaireItem"
-        }
-      ],
-      "dateCreated": "2018-08-01T06:00:00.000Z"
-    }
-  ]
-}</code></pre>
+        <pre><code data-include="../../fixtures/v1p1/caliperEntitySurvey.json"></code></pre>
       </figure>
     </section>
 
@@ -906,22 +409,7 @@
 
       <figure class="example">
         <figcaption><code>SurveyInvitation</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/invitations/users/112233",
-  "type": "SurveyInvitation",
-  "sentCount": 1,
-  "sentDate": "2018-11-15T10:05:00.000Z",
-  "rater": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "survey": {
-    "id": "https://example.edu/survey/1",
-    "type": "Survey"
-  },
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+        <pre><code data-include="../../fixtures/v1p1/caliperEntitySurveyInvitation.json"></code></pre>
       </figure>
     </section>
 
@@ -930,22 +418,7 @@
 
       <figure class="example">
         <figcaption><code>Questionnaire</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30",
-  "type": "Questionnaire",
-  "items": [
-    {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-      "type": "QuestionnaireItem"
-    },
-    {
-      "id": "https://example.edu/surveys/100/questionnaires/30/items/2",
-      "type": "QuestionnaireItem"
-    }
-  ],
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+        <pre><code data-include="../../fixtures/v1p1/caliperEntityQuestionnaire.json"></code></pre>
       </figure>
     </section>
 
@@ -954,25 +427,7 @@
 
       <figure class="example">
         <figcaption><code>QuestionnaireItem</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/1",
-  "type": "QuestionnaireItem",
-  "question": {
-    "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
-    "type": "RatingScaleQuestion",
-    "questionPosed": "How satisfied are you with our services?",
-    "scale": {
-      "id": "https://example.edu/scale/2",
-      "type": "LikertScale",
-      "points": 4,
-      "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-      "itemValues": ["-2", "-1", "1", "2"]
-    }
-  },
-  "categories": ["teaching effectiveness", "Course structure"],
-  "weight": 1.0
-}</code></pre>
+        <pre><code data-include="../../fixtures/v1p1/caliperEntityQuestionnaireItem.json"></code></pre>
       </figure>
     </section>
 
@@ -981,12 +436,7 @@
 
       <figure class="example">
         <figcaption><code>Question</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/5/question",
-  "type": "Question",
-  "questionPosed": "What is this generic question about?",
-}</code></pre>
+        <pre><code data-include="../../fixtures/v1p1/caliperEntityQuestion.json"></code></pre>
       </figure>
 
       <section class="informative">
@@ -994,19 +444,7 @@
 
         <figure class="example">
           <figcaption><code>RatingScaleQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/1/question",
-  "type": "RatingScaleQuestion",
-  "questionPosed": "What is this generic scale question about?",
-  "scale": {
-    "id": "https://example.edu/scale/2",
-    "type": "LikertScale",
-    "points": 4,
-    "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-    "itemValues": ["-2", "-1", "1", "2"]
-  }
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityRatingScaleQuestion.json"></code></pre>
         </figure>
       </section>
 
@@ -1015,16 +453,7 @@
 
         <figure class="example">
           <figcaption><code>DateTimeQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/3/question",
-  "type": "DateTimeQuestion",
-  "questionPosed": "When would you be available for an exam next term?",
-  "minDateTime": "2018-09-01T06:00:00.000Z",
-  "minLabel": "Start of Term",
-  "maxDateTime": "2018-12-30T06:00:00.000Z",
-  "maxLabel": "End of Term"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityDateTimeQuestion.json"></code></pre>
         </figure>
       </section>
 
@@ -1033,20 +462,7 @@
 
         <figure class="example">
           <figcaption><code>MultiselectQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/4/question",
-  "type": "MultiselectQuestion",
-  "questionPosed": "What do you want to study today?",
-  "points": 4,
-  "itemLabels": ["Calculus", "Number theory", "Combinatorics", "Algebra"],
-  "itemValues": [
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/2",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/3",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/4",
-  ],
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityMultiselectQuestion.json"></code></pre>
         </figure>
       </section>
 
@@ -1055,12 +471,7 @@
 
         <figure class="example">
           <figcaption><code>OpenEndedQuestion</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/2/question",
-  "type": "OpenEndedQuestion",
-  "questionPosed": "What would you change about your course?"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityOpenEndedQuestion.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -1073,16 +484,7 @@
 
         <figure class="example">
           <figcaption><code>RatingScaleResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/1/users/554433/responses/1",
-  "type": "RatingScaleResponse",
-  "selections": ["Satisfied"],
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityRatingScaleResponse.json"></code></pre>
         </figure>
       </section>
 
@@ -1091,16 +493,7 @@
 
         <figure class="example">
           <figcaption><code>DateTimeResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/4/users/554433/responses/4",
-  "type": "DateTimeResponse",
-  "dateTimeSelected": "2018-12-15T06:00:00.000Z",
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityDateTimeResponse.json"></code></pre>
         </figure>
       </section>
 
@@ -1109,19 +502,7 @@
 
         <figure class="example">
           <figcaption><code>MultiselectResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/5/users/554433/responses/5",
-  "type": "MultiselectResponse",
-  "selections": [
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
-    "https://example.edu/terms/201801/courses/7/sections/1/objectives/2"
-  ],
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityMultiselectResponse.json"></code></pre>
         </figure>
       </section>
 
@@ -1130,16 +511,7 @@
 
         <figure class="example">
           <figcaption><code>OpenEndedResponse</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/surveys/100/questionnaires/30/items/2/users/554433/responses/2",
-  "type": "OpenEndedResponse",,
-  "value": "I feel that ...",
-  "startedAtTime": "2018-08-01T05:55:48.000Z",
-  "endedAtTime": "2018-08-01T06:00:00.000Z",
-  "duration": "PT4M12S"
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityOpenEndedResponse.json"></code></pre>
         </figure>
       </section>
     </section>
@@ -1149,12 +521,7 @@
 
       <figure class="example">
         <figcaption><code>Scale</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/scale/1",
-  "type": "Scale",
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+        <pre><code data-include="../../fixtures/v1p1/caliperEntityScale.json"></code></pre>
       </figure>
 
       <section class="informative">
@@ -1162,15 +529,7 @@
 
         <figure class="example">
           <figcaption><code>LikertScale</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/scale/2",
-  "type": "LikertScale",
-  "points": 4,
-  "itemLabels": ["Strongly Disagree", "Disagree", "Agree", "Strongly Agree"],
-  "itemValues": ["-2", "-1", "1", "2"],
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityLikertScale.json"></code></pre>
         </figure>
       </section>
 
@@ -1179,17 +538,7 @@
 
         <figure class="example">
           <figcaption><code>NumericScale</code> describe JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SurveyProfile-extension",
-  "id": "https://example.edu/scale/4",
-  "type": "NumericScale",
-  "minValue": 0.0,
-  "minLabel": "Disliked",
-  "maxValue": 10.0,
-  "maxLabel": "Liked",
-  "step": 0.5,
-  "dateCreated": "2018-08-01T06:00:00.000Z"
-}</code></pre>
+          <pre><code data-include="../../fixtures/v1p1/caliperEntityNumericScale.json"></code></pre>
         </figure>
       </section>
     </section>

--- a/profiles/toollaunch/caliper-profile-tool_launch-v1p1.html
+++ b/profiles/toollaunch/caliper-profile-tool_launch-v1p1.html
@@ -190,8 +190,6 @@
 
     <p>Note that implementers by best practice SHOULD include the <code>messageType</code> associated with an
         <a href="#LtiLink">LtiLink</a> entity to provide context for how the link would have been intended to be used.</p>
-
-    </section>
 </section>
 
 <section id="lti-messageTypes">
@@ -243,138 +241,16 @@
 
                 <figure class="example">
                     <figcaption>ToolLaunchEvent (<em>Launched</em>) JSON-LD</figcaption>
-<pre><code>{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
-  "id": "urn:uuid:a2e8b214-4d4a-4456-bb4c-099945749117",
-  "type": "ToolLaunchEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Launched",
-  "object": {
-    "id": "https://example.com/lti/tool",
-    "type": "SoftwareApplication"
-  },
-  "eventTime": "2018-11-15T10:15:00.000Z",
-  "edApp": {
-    "id": "https://example.edu",
-    "type": "SoftwareApplication"
-  },
-  "referrer": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/pages/1",
-    "type": "WebPage"
-  },
-  "group": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "type": "CourseSection",
-    "courseNumber": "CPS 435-01",
-    "academicSession": "Fall 2018"
-  },
-  "membership": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-    "type": "Membership",
-    "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-    "roles": [ "Learner" ],
-    "status": "Active",
-    "dateCreated": "2018-08-01T06:00:00.000Z"
-  },
-  "session": {
-    "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-    "type": "Session",
-    "startedAtTime": "2018-11-15T10:00:00.000Z"
-  },
-  "target": {
-    "id": "https://tool.com/link/123",
-    "type": "LtiLink",
-    "messageType": "LtiResourceLinkRequest"
-  },
-  "federatedSession": {
-    "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
-    "type": "LtiSession",
-    "user": {
-      "id": "https://example.edu/users/554433",
-      "type": "Person"
-    },
-    "dateCreated": "2018-11-15T10:15:00.000Z",
-    "startedAtTime": "2018-11-15T10:15:00.000Z",
-    "messageParameters": {
-       "iss": "https://example.edu",
-       "sub": "https://example.edu/users/554433",
-       "aud": ["https://example.com/lti/tool"],
-       "exp": 1510185728,
-       "iat": 1510185228,
-       "azp": "962fa4d8-bcbf-49a0-94b2-2de05ad274af",
-       "nonce": "fc5fdc6d-5dd6-47f4-b2c9-5d1216e9b771",
-       "name": "Ms Jane Marie Doe",
-       "given_name": "Jane",
-       "family_name": "Doe",
-       "middle_name": "Marie",
-       "picture": "https://example.edu/jane.jpg",
-       "email": "jane@example.edu",
-       "locale": "en-US",
-       "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "07940580-b309-415e-a37c-914d387c1150",
-       "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
-       "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
-       "https://purl.imsglobal.org/spec/lti/claim/roles": [
-          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
-          "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
-          "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor"
-       ],
-       "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": [
-          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"
-       ],
-       "https://purl.imsglobal.org/spec/lti/claim/context": {
-          "id": "https://example.edu/terms/201801/courses/7/sections/1",
-          "label": "CPS 435-01",
-          "title": "CPS 435 Learning Analytics, Section 01",
-          "type": ["http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection"]
-       },
-       "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
-          "id": "200d101f-2c14-434a-a0f3-57c2a42369fd",
-          "description": "Assignment to introduce who you are",
-          "title": "Introduction Assignment"
-       },
-       "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
-          "guid": "https://example.edu",
-          "contact_email": "support@example.edu",
-          "description": "An Example Tool Platform",
-          "name": "Example Tool Platform",
-          "url": "https://example.edu",
-          "product_family_code": "ExamplePlatformVendor-Product",
-          "version": "1.0"
-       },
-       "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
-          "document_target": "iframe",
-          "height": 320,
-          "width": 240,
-          "return_url": "https://example.edu/terms/201801/courses/7/sections/1/pages/1"
-       },
-       "https://purl.imsglobal.org/spec/lti/claim/custom": {
-          "xstart": "2017-04-21T01:00:00Z",
-          "request_url": "https://tool.com/link/123"
-       },
-       "https://purl.imsglobal.org/spec/lti/claim/lis": {
-          "person_sourcedid": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
-          "course_offering_sourcedid": "example.edu:SI182-F16",
-          "course_section_sourcedid": "example.edu:SI182-001-F16"
-       },
-       "http://www.ExamplePlatformVendor.com/session": {
-          "id": "89023sj890dju080"
-       }
-    }
-  }
-}</code></pre>
-            </figure>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventToolLaunchLaunched.json"></code></pre>
+                </figure>
 
-            <p>Legacy LTI systems using LTI 1.0 basic launch requests might
-                populate the <code>messageParameters</code> property in
-                the <code>federatedSession</code> as in the following figure.</p>
+                <p>Legacy LTI systems using LTI 1.0 basic launch requests might
+                    populate the <code>messageParameters</code> property in
+                    the <code>federatedSession</code> as in the following figure.</p>
 
-            <figure class="example">
-                <figcaption>LTI 1.0 Basic Launch Request Message Parameters</figcaption>
-<pre><code>{
+                <figure class="example">
+                    <figcaption>LTI 1.0 Basic Launch Request Message Parameters</figcaption>
+                    <pre><code>{
   "messageParameters": {
       "lti_message_type": "basic-lti-launch-request",
       "lti_version": "LTI-1p0",
@@ -397,144 +273,75 @@
             </section>
 
             <section class="informative">
-            <h3>Returned</h3>
+                <h3>Returned</h3>
 
-            <p>Below is an example of a full JSON-LD payload for a <a href="#event-toollaunch">ToolLaunchEvent</a>
-                using the <em>Returned</em> action, representing the closure of an LTI workflow that started with a
-                resource link launch request.</p>
+                <p>Below is an example of a full JSON-LD payload for a <a href="#event-toollaunch">ToolLaunchEvent</a>
+                    using the <em>Returned</em> action, representing the closure of an LTI workflow that started with a
+                    resource link launch request.</p>
 
-            <p>The <a>Platform</a> is still represented by the <code>edApp</code> property, and the tool being returned
-                from is still represented by the <code>object</code> property. The <code>federatedSession</code>
-                property is also retained, and corresponds to the <code>federatedSession</code> referenced in the event
-                that represented the <code>Launched</code> action. The <code>target</code> property of the event is the
-                launch presentation return URL that the platform sent in the original LTI launch properties.</p>
-
-            <figure class="example">
-                <figcaption>ToolLaunchEvent (<em>Returned</em>) JSON-LD</figcaption>
-<pre><code>{
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
-    "id": "urn:uuid:a2e8b214-4d4a-4456-bb4c-099945749117",
-    "type": "ToolLaunchEvent",
-    "actor": {
-      "id": "https://example.edu/users/554433",
-      "type": "Person"
-    },
-    "action": "Returned",
-    "object": {   
-      "id": "https://example.com/lti/tool",
-      "type": "SoftwareApplication"
-    },
-    "eventTime": "2018-11-15T10:15:00.000Z",
-    "edApp": {   
-      "id": "https://example.edu",
-      "type": "SoftwareApplication"    
-    },
-    "referrer": {   
-      "id": "https://tool.com/lti/123",
-      "type": "LtiLink"
-    },
-    "group": {   
-      "id": "https://example.edu/terms/201801/courses/7/sections/1",
-      "type": "CourseSection",
-      "courseNumber": "CPS 435-01",
-      "academicSession": "Fall 2018"
-    },
-    "membership": {   
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
-      "type": "Membership",
-      "member": "https://example.edu/users/554433",
-      "organization": "https://example.edu/terms/201801/courses/7/sections/1",
-      "roles": [ "Learner" ],
-      "status": "Active",
-      "dateCreated": "2018-08-01T06:00:00.000Z"
-    },
-    "session": {   
-      "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-      "type": "Session",
-      "startedAtTime": "2018-11-15T10:00:00.000Z"
-    },
-    "target": {
-      "id": "https://example.edu/terms/201801/courses/7/sections/1/pages/1",
-      "type": "Link"
-    },
-    "federatedSession": {   
-      "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
-      "type": "LtiSession",
-      "user": {
-        "id": "https://example.edu/users/554433",
-        "type": "Person"
-      },
-      "dateCreated": "2018-11-15T10:15:00.000Z",
-      "startedAtTime": "2018-11-15T10:15:00.000Z"
-    }
-}</code></pre>
-                    </figure>
-                </section>
-            </section>
-        </section>
-
-        <section class="informative">
-            <h3>Entity Describes</h3>
-
-            <section class="informative">
-                <h3>Link</h3>
-
-                <p>Below is an example of a <a href="#entity-link">Link</a> entity describe that can also be sent to an
-                    endpoint.</p>
+                <p>The <a>Platform</a> is still represented by the <code>edApp</code> property, and the tool being returned
+                    from is still represented by the <code>object</code> property. The <code>federatedSession</code>
+                    property is also retained, and corresponds to the <code>federatedSession</code> referenced in the event
+                    that represented the <code>Launched</code> action. The <code>target</code> property of the event is the
+                    launch presentation return URL that the platform sent in the original LTI launch properties.</p>
 
                 <figure class="example">
-                    <figcaption>Link describe JSON-LD</figcaption>
-<pre><code>
-{
-"@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
-"id": "https://example.edu/terms/201801/courses/7/sections/1/pages/1",
-"type": "Link"
-}</code></pre>
-                </figure>
-            </section>
-
-
-            <section class="informative">
-                <h3>LtiLink</h3>
-
-                <p>Below is an example of a <a href="#entity-ltiLink">LtiLink</a> entity describe that can also be
-                    sent to an endpoint.</p>
-
-                <figure class="example">
-                    <figcaption>LtiLink describe JSON-LD</figcaption>
-<pre><code>
-{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
-  "id": "https://tool.com/link/123",
-  "type": "LtiLink",
-  "messageType": "LtiResourceLinkRequest"
-}</code></pre>
+                    <figcaption>ToolLaunchEvent (<em>Returned</em>) JSON-LD</figcaption>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventToolLaunchReturned.json"></code></pre>
                 </figure>
             </section>
         </section>
     </section>
 
-    <section class="appendix informative" id="revisionhistory">
-        <h2>Revision History</h2>
-        <section>
-            <h3>Version History</h3>
-            <table title="Revision History" summary="Publication history and revision details for this specification.">
-                <thead>
-                <tr>
-                    <th>Version No.</th>
-                    <th>Release Date</th>
-                    <th>Comments</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td>IMS Base Document 1.1</td>
-                    <td>30 June 2019</td>
-                    <td>The first Base Document release.</td>
-                </tr>
-                </tbody>
-            </table>
+    <section class="informative">
+        <h3>Entity Describes</h3>
+
+        <section class="informative">
+            <h3>Link</h3>
+
+            <p>Below is an example of a <a href="#entity-link">Link</a> entity describe that can also be sent to an
+                endpoint.</p>
+
+            <figure class="example">
+                <figcaption>Link describe JSON-LD</figcaption>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityLink.json"></code></pre>
+            </figure>
         </section>
+
+        <section class="informative">
+            <h3>LtiLink</h3>
+
+            <p>Below is an example of a <a href="#entity-ltiLink">LtiLink</a> entity describe that can also be
+                sent to an endpoint.</p>
+
+            <figure class="example">
+                <figcaption>LtiLink describe JSON-LD</figcaption>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityLtiLink.json"></code></pre>
+            </figure>
+        </section>
+    </section>
+</section>
+
+<section class="appendix informative" id="revisionhistory">
+    <h2>Revision History</h2>
+    <section>
+        <h3>Version History</h3>
+        <table title="Revision History" summary="Publication history and revision details for this specification.">
+            <thead>
+            <tr>
+                <th>Version No.</th>
+                <th>Release Date</th>
+                <th>Comments</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>IMS Base Document 1.1</td>
+                <td>30 June 2019</td>
+                <td>The first Base Document release.</td>
+            </tr>
+            </tbody>
+        </table>
     </section>
     <section>
         <h3>Changes from previous version</h3>

--- a/profiles/tooluse/caliper-profile-tool_use-v1p1.html
+++ b/profiles/tooluse/caliper-profile-tool_use-v1p1.html
@@ -215,90 +215,7 @@
 
                 <figure class="example">
                     <figcaption><code>ToolUseEvent</code> JSON-LD</figcaption>
-<pre><code>
-{
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolUseProfile-extension",
-  "id": "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d916",
-  "type": "ToolUseEvent",
-  "actor": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "action": "Used",
-  "object": {
-    "id": "https://example.edu",
-    "type": "SoftwareApplication"
-  },
-  "eventTime": "2019-11-15T10:15:00.000Z",
-  "edApp": "https://example.edu",
-  "generated": {
-    "id": "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d912",
-    "type": "AggregateMeasureCollection",
-    "items": [
-        {
-            "id": "urn:uuid:21c3f9f2-a9ef-4f65-bf9a-0699ed85e2c7",
-            "type": "AggregateMeasure",
-            "metric": "MinutesOnTask",
-            "name": "Minutes On Task",
-            "metricValue": 873.0,
-            "startedAtTime": "2019-08-15T10:15:00.000Z",
-            "endedAtTime": "2019-11-15T10:15:00.000Z"
-        },
-        {
-            "id": "urn:uuid:c3ba4c01-1f17-46e0-85dd-1e366e6ebb81",
-            "type": "AggregateMeasure",
-            "metric": "UnitsCompleted",
-            "name": "Units Completed",
-            "metricValue": 12.0,
-            "maxMetricValue": 25.0,
-            "startedAtTime": "2019-08-15T10:15:00.000Z",
-            "endedAtTime": "2019-11-15T10:15:00.000Z"
-        }
-    ]
-  },
-  "group": {
-      "id": "https://example.edu/terms/201601/courses/7/sections/1",
-      "type": "CourseSection",
-      "academicSession": "Fall 2016",
-      "courseNumber": "CPS 435-01",
-      "name": "CPS 435 Learning Analytics, Section 01",
-      "category": "seminar",
-      "subOrganizationOf": {
-          "id": "https://example.edu/terms/201601/courses/7",
-          "type": "CourseOffering",
-          "courseNumber": "CPS 435"
-      },
-      "dateCreated": "2016-08-01T06:00:00.000Z"
-  },
-  "membership": {
-      "id": "https://example.edu/terms/201601/courses/7/sections/1/rosters/1/members/554433",
-      "type": "Membership",
-      "member": {
-          "id": "https://example.edu/users/554433",
-          "type": "Person"
-      },
-      "organization": {
-          "id": "https://example.edu/terms/201601/courses/7/sections/1",
-          "type": "CourseSection",
-          "subOrganizationOf": {
-              "id": "https://example.edu/terms/201601/courses/7",
-              "type": "CourseOffering"
-          }
-      },
-      "roles": [ "Learner" ],
-      "status": "Active",
-      "dateCreated": "2016-11-01T06:00:00.000Z"
-  },
-  "session": {
-      "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
-      "type": "Session",
-      "user": {
-          "id": "https://example.edu/users/554433",
-          "type": "Person"
-      },
-      "startedAtTime": "2016-09-15T10:00:00.000Z"
-  }
-}</code></pre>
+                    <pre><code data-include="../../fixtures/v1p1/caliperEventToolUseUsedWithProgress.json"></code></pre>
                 </figure>
             </section>
         </section>
@@ -307,26 +224,15 @@
     <section class="informative">
         <h3>Entity Describes</h3>
 
-            <section class="informative">
-                <h3>AggregateMeasure</h3>
+        <section class="informative">
+            <h3>AggregateMeasure</h3>
 
-                <p>Below is an example of a <a href="#entity-aggregateMeasure">AggregateMeasure</a> entity describe that can
-                    also be sent to an endpoint.</p>
+            <p>Below is an example of a <a href="#entity-aggregateMeasure">AggregateMeasure</a> entity describe that can
+                also be sent to an endpoint.</p>
 
-                <figure class="example">
-                    <figcaption><code>AggregateMeasure</code> describe JSON-LD</figcaption>
-<pre><code>
-{
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolUseProfile-extension",
-    "id": "urn:uuid:c3ba4c01-1f17-46e0-85dd-1e366e6ebb81",
-    "type": "AggregateMeasure",
-    "metric": "UnitsCompleted",
-    "name": "Units Completed",
-    "metricValue": 12.0,
-    "maxMetricValue": 25.0,
-    "startedAtTime": "2019-08-15T10:15:00.000Z",
-    "endedAtTime": "2019-11-15T10:15:00.000Z"
-}</code></pre>
+            <figure class="example">
+                <figcaption><code>AggregateMeasure</code> describe JSON-LD</figcaption>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityAggregateMeasure.json"></code></pre>
             </figure>
         </section>
 
@@ -337,33 +243,7 @@
 
             <figure class="example">
                 <figcaption><code>AggregateMeasureCollection</code> describe JSON-LD</figcaption>
-<pre><code>
-{
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolUseProfile-extension",
-    "id": "urn:uuid:60b4db01-f1e5-4a7f-add9-6a8f761625b1",
-    "type": "AggregateMeasureCollection",
-    "items": [
-        {
-            "id": "urn:uuid:21c3f9f2-a9ef-4f65-bf9a-0699ed85e2c7",
-            "type": "AggregateMeasure",
-            "metric": "MinutesOnTask",
-            "name": "Minutes On Task",
-            "metricValue": 873.0,
-            "startedAtTime": "2019-08-15T10:15:00.000Z",
-            "endedAtTime": "2019-11-15T10:15:00.000Z"
-        },
-        {
-            "id": "urn:uuid:c3ba4c01-1f17-46e0-85dd-1e366e6ebb81",
-            "type": "AggregateMeasure",
-            "metric": "UnitsCompleted",
-            "name": "Units Completed",
-            "metricValue": 12.0,
-            "maxMetricValue": 25.0,
-            "startedAtTime": "2019-08-15T10:15:00.000Z",
-            "endedAtTime": "2019-11-15T10:15:00.000Z"
-        }
-    ]
-}</code></pre>
+                <pre><code data-include="../../fixtures/v1p1/caliperEntityAggregateMeasureCollection.json"></code></pre>
             </figure>
         </section>
     </section>


### PR DESCRIPTION
This PR replaces hard-coded (and duplicate) JSON-LD examples with new `<section>` tags that use the `data-include` attribute to draw the examples directly from the fixtures/v1p1 branch.  Thanks to @ssciolla for doing this work.