### PR TITLE
Event.profile is an optional property

### DIFF
--- a/fragments/events/caliper-event-event.html
+++ b/fragments/events/caliper-event-event.html
@@ -108,7 +108,7 @@
             <code>profile</code> [Term](#termDef) value may be specified per <code>Event</code>. For a generic
             <code>Event</code> set the <code>profile</code> property value to the string term
             <em>GeneralProfile</em>.</td>
-        <td>Required</td>
+        <td>Optional</td>
     </tr>
     <tr>
         <td>actor</td>


### PR DESCRIPTION
This PR corrects an error in the description of `Event.profile`.  The property is optional.