### PR TITLE
Tool Use Profile: add note regarding use of Aggregate Measures to express learner progress

### DIFF
--- a/fragments/events/caliper-event-tooluse.html
+++ b/fragments/events/caliper-event-tooluse.html
@@ -78,6 +78,11 @@
         <td>An <a href="#AggregateMeasureCollection">AggregateMeasureCollection</a> created or generated
             as a result of the interaction. The <code>generated</code> value MUST be expressed either as an object or
             as a string corresponding to the generated entity’s <a href="#iriDef">IRI</a>.
+            </br>
+            Note that if the sender of the event wants to send aggregate measure information
+            as part of this <a href="#ToolUseEvent">ToolUseEvent</a> it should, by best practice, send a single
+            <a href="AggregateMeasureCollection">AggregateMeasureCollection</a> as
+            the <code>generated</code> value.
         </td>
         <td>Optional</td>
     </tr>

--- a/fragments/profiles/caliper-profile-tooluse.html
+++ b/fragments/profiles/caliper-profile-tooluse.html
@@ -40,7 +40,15 @@
 
 <p>The Tool Use Profile defines a <a href="#ToolUseEvent">ToolUseEvent</a> for describing a
     <a href="#Person">Person</a> using a learning tool in a way that the tool's creators have
-    determined is an indication of a learning interaction. A single action is described:
+    determined is an indication of a learning interaction. A single action is described.
+
+<p class="note" title="Expressing learner progress using Aggregate Measures">
+    A <a href="#ToolUseEvent">ToolUseEvent</a> MAY also be used to communicate learner progress by referencing a
+    collection of one or more <a href="#AggregateMeasure">AggregateMeasure</a> entities. A <a href="#sensor">Sensor</a>
+    that needs to report such information should assign an
+    <a href="#entity-AggregateMeasureCollection">AggregateMeasureCollection</a>
+    as the <code>generated</code> value for any reported aggregate metric information.
+<p>
 
 <table class="data">
     <thead>


### PR DESCRIPTION
This PR adds adds guidance relative to expressing notions of learner progress by assigning an `AggregateMeasureCollection` to `ToolUseEvent.generated`. 