### PR TITLE
Add first set of note highlights; remove class=data attribute from <table> tag

### DIFF
--- a/caliper-spec-v1p2.html
+++ b/caliper-spec-v1p2.html
@@ -337,7 +337,8 @@
             <li>other requirements</li>
         </ul>
 
-        <p>As an example, the <a href="#ForumProfile">Forum Profile</a> models a set of activities associated
+
+        <p>For example, the <a href="#ForumProfile">Forum Profile</a> models a set of activities associated
             with online discussions involving instructors and learners. The profile currently includes a
             <a href="#ForumEvent">ForumEvent</a>, <a href="#MessageEvent">MessageEvent</a>,
             <a href="#NavigationEvent">NavigationEvent</a>, <a href="#ThreadEvent">ThreadEvent</a> and
@@ -346,8 +347,7 @@
             to it, viewing a thread, posting a message in reply to an earlier post and then marking the message as
             read.</p>
 
-        <p>
-            Extending Caliper's information model involves designing a new profile or enhancing an existing one.
+        <p>Extending Caliper's information model involves designing a new profile or enhancing an existing one.
             Implementers are free to implement only those Caliper profiles as are necessary to model a learning
             domain. A video platform provider may decide that only the
             <a href="#AssignableProfile">Assignable Profile</a>, <a href="#MediaProfile">Media Profile</a> and
@@ -441,10 +441,12 @@
                 an economical way for Caliper to communicate document semantics to services interested in consuming
                 Caliper event data.</p>
 
-            <p>IMS Global provides a remote Caliper 1.1 <a href="#jsonldDef">JSON-LD</a> context document
+            <p class="note" title="Caliper JSON-LD Context document">IMS Global provides a Caliper
+                <a href="#jsonldDef">JSON-LD</a> context document
                 (<a href="http://purl.imsglobal.org/ctx/caliper/v1p2/">http://purl.imsglobal.org/ctx/caliper/v1p2/</a>)
-                for mapping Caliper <a href="#termDef">Terms</a> to <a href="#iriDef">IRIs</a>. Implementers are
-                encouraged to familiarize themselves with the term definitions described therein.</p>
+                for remote mapping of Caliper <a href="#termDef">Terms</a> to <a href="#iriDef">IRIs</a>.
+                Implementers are encouraged to familiarize themselves with the term definitions
+                described therein.</p>
 
             <h4>Requirements</h4>
             <ul>
@@ -528,16 +530,18 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
                 <a href="#entity">Entity</a> described by the model is provisioned with an <code>id</code> rather than
                 <code>@id</code> property for identifying the resource.</p>
 
-            <p>Every <a href="#entity">Entity</a> MUST be assigned an identifier in the form of a valid
-                <a href="#iriDef">IRI</a> or a blank node identifier. The <a href="#iriDef">IRI</a> MUST be unique and
-                persistent.  The <a href="#iriDef">IRI</a> SHOULD be dereferenceable; i.e., capable of returning a
-                representation of the <a href="#entity">Entity</a>.  A <a href="#uriDef">URI</a> employing the
-                <a href="#urnDef">URN</a> scheme MAY also be utilized.</p>
+            <p class="note" title="Entity identifiers">Every <a href="#entity">Entity</a> MUST be
+                assigned an identifier in the form of a valid <a href="#iriDef">IRI</a> or a blank
+                node identifier. The <a href="#iriDef">IRI</a> MUST be unique and persistent.
+                The <a href="#iriDef">IRI</a> SHOULD be dereferenceable; i.e., capable of returning a
+                representation of the <a href="#entity">Entity</a>.  A <a href="#uriDef">URI</a>
+                employing the <a href="#urnDef">URN</a> scheme MAY also be utilized.</p>
 
-            <p>Unlike Entities, each <a href="#event">Event</a> MUST be assigned a 128-bit long universally unique
+            <p class="note" title="Event identifiers">Unlike Entities, each
+                <a href="#event">Event</a> MUST be assigned a 128-bit long universally unique
                 identifier (<a href="#uuidDef">UUID</a>) formatted as a <a href="#urnDef">URN</a> per
-                <a href="#rfc4122">RFC 4122</a>, which describes a <a href="#urnDef">URN</a> namespace for
-                <a href="#uuidDef">UUIDs</a>.</p>
+                <a href="#rfc4122">RFC 4122</a>, which describes a <a href="#urnDef">URN</a>
+                namespace for <a href="#uuidDef">UUIDs</a>.</p>
 
             <figure class="example">
                 <figcaption> - Event and Entity identifiers</figcaption>
@@ -632,9 +636,11 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
                 might also be carried with the <a href="#anonymousDef">anonymous</a> <a href="#Entity">Entity</a>
                 within the <a href="#Event">Event</a>.</p>
 
-            <p><a href="#sensor">Sensor</a> applications SHOULD NOT use this method to convey
+            <p class="note" title="Entity depersonalization"><a href="#sensor">Sensor</a>
+                applications SHOULD NOT use this method to convey
                 <a href="#depersonalizedDef">depersonalized</a> entities. The methods by which
-                <a href="#sensor">Sensor</a> applications might <a href="#depersonalizedDef">depersonalize</a> entities
+                <a href="#sensor">Sensor</a> applications might
+                <a href="#depersonalizedDef">depersonalize</a> entities
                 to obscure or safeguard their identity are not within the scope of this document.</p>
 
             <p>The following example illustrates how an <a href="#anonymousDef">anonymous</a>
@@ -711,7 +717,7 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
             <p>Caliper <a href="#envelope">Envelope</a> properties are listed below. The <code>sensor</code>,
                 <code>sendTime</code>, <code>dataVersion</code> and <code>data</code> properties are required. Each
                 property MUST be referenced only once.  No custom properties are permitted.</p>
-            <table class="data">
+            <table>
                 <thead>
                 <tr>
                     <th>Property</th>
@@ -791,14 +797,16 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
                 <a href="#envelope">Envelope</a>.  Messages MUST be sent using the POST request method.
                 The HTTP <code>Host</code> and <code>Content-Type</code> request header fields MUST be set.</p>
 
-            <p>A <a href="#sensor">Sensor</a> SHOULD also set the <code>Authorization</code> request header field using
+            <p class="note" title="Authorization header">A <a href="#sensor">Sensor</a> SHOULD
+                also set the <code>Authorization</code> request header field using
                 the "Bearer" authentication scheme described in <a href="#rfc6750">RFC 6750</a>,
-                <a href="https://tools.ietf.org/html/rfc6750#section-2">Section 2.1</a>. The <code>b64token</code>
-                authorization credential sent by a <a href="#sensor">Sensor</a> MUST be one the
-                <a href="#endpoint">Endpoint</a> can validate although the credential MAY be opaque to the emitting
-                <a href="#sensor">Sensor</a> itself.</p>
+                <a href="https://tools.ietf.org/html/rfc6750#section-2">Section 2.1</a>.
+                The <code>b64token</code> authorization credential sent by a
+                <a href="#sensor">Sensor</a> MUST be one the
+                <a href="#endpoint">Endpoint</a> can validate although the credential MAY be
+                opaque to the emitting <a href="#sensor">Sensor</a> itself.</p>
 
-            <table class="data">
+            <table>
                 <thead>
                 <tr>
                     <th>Request Header</th>
@@ -884,8 +892,10 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
                 states, using the standard method for reporting problem details described in
                 <a href="#rfc7807">RFC 7807</a>.</p>
 
-            <p>Caliper <a href="#endpoint">Endpoint</a> implementers should bear in mind that some Caliper
-                <a href="#sensor">Sensor</a> implementations may lack sophisticated error handling.</p>
+            <p class="note" title="Beware simple Sensor implementations">Caliper
+                <a href="#endpoint">Endpoint</a> implementers should bear in mind that some Caliper
+                <a href="#sensor">Sensor</a> implementations may lack sophisticated error
+                handling.</p>
         </section>
 
         <section id="endpoint_config">
@@ -914,7 +924,7 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
             <p>The properties of an Endpoint configuration are listed below. Each property MUST be included no more than
                 once. No custom properties are permitted.</p>
 
-            <table class="data">
+            <table>
                 <thead>
                 <tr>
                     <th>Property</th>

--- a/fragments/entities/caliper-entity-agent.html
+++ b/fragments/entities/caliper-entity-agent.html
@@ -24,7 +24,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-aggregatemeasure.html
+++ b/fragments/entities/caliper-entity-aggregatemeasure.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-aggregatemeasurecollection.html
+++ b/fragments/entities/caliper-entity-aggregatemeasurecollection.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-annotation.html
+++ b/fragments/entities/caliper-entity-annotation.html
@@ -27,7 +27,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-assessment.html
+++ b/fragments/entities/caliper-entity-assessment.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-assessmentitem.html
+++ b/fragments/entities/caliper-entity-assessmentitem.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-assignabledigitalresource.html
+++ b/fragments/entities/caliper-entity-assignabledigitalresource.html
@@ -29,7 +29,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-attempt.html
+++ b/fragments/entities/caliper-entity-attempt.html
@@ -22,7 +22,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-audioobject.html
+++ b/fragments/entities/caliper-entity-audioobject.html
@@ -17,7 +17,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-bookmarkannotation.html
+++ b/fragments/entities/caliper-entity-bookmarkannotation.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-chapter.html
+++ b/fragments/entities/caliper-entity-chapter.html
@@ -16,7 +16,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-collection.html
+++ b/fragments/entities/caliper-entity-collection.html
@@ -22,7 +22,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-comment.html
+++ b/fragments/entities/caliper-entity-comment.html
@@ -1,6 +1,6 @@
 <h3>Comment</h3>
 
-<p>A Caliper <code>Comment</code> models a person's qualitative reactions to a <code>Entity</code>.</p>
+<p>A Caliper <code>Comment</code> models a person's qualitative reactions to a <a href="#Entity">Entity</a>.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -17,7 +17,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>
@@ -54,7 +54,7 @@
         >Entity</a> | <a href=
            "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>The <code>Entity</code> which received the comment. The <code>commentedOn</code> value MUST
+        <td>The <a href="#Entity">Entity</a> which received the comment. The <code>commentedOn</code> value MUST
             be expressed either as an object or as a string corresponding to the IRI of the resource that was
             commented on.
         </td>

--- a/fragments/entities/caliper-entity-courseoffering.html
+++ b/fragments/entities/caliper-entity-courseoffering.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-coursesection.html
+++ b/fragments/entities/caliper-entity-coursesection.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-datetimequestion.html
+++ b/fragments/entities/caliper-entity-datetimequestion.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-datetimeresponse.html
+++ b/fragments/entities/caliper-entity-datetimeresponse.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-digitalresource.html
+++ b/fragments/entities/caliper-entity-digitalresource.html
@@ -34,7 +34,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-digitalresourcecollection.html
+++ b/fragments/entities/caliper-entity-digitalresourcecollection.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-document.html
+++ b/fragments/entities/caliper-entity-document.html
@@ -16,7 +16,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-entity.html
+++ b/fragments/entities/caliper-entity-entity.html
@@ -115,7 +115,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>
@@ -177,7 +177,7 @@
         <td>otherIdentifiers</td>
         <td>Array</td>
         <td>An ordered collection of <a href="#SystemIdentifier">SystemIdentifier</a> entities that represent
-            other identifiers for this <code>Entity</code> that are known to the <a href="#Sensor">Sensor</a>.
+            other identifiers for this <a href="#Entity">Entity</a> that are known to the <a href="#Sensor">Sensor</a>.
             Each array item MUST be expressed either as an object or as a string corresponding to the
             item's <a href="#iriDef">IRI</a>.</td>
         <td>Optional</td>

--- a/fragments/entities/caliper-entity-fillinblankresponse.html
+++ b/fragments/entities/caliper-entity-fillinblankresponse.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-forum.html
+++ b/fragments/entities/caliper-entity-forum.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-frame.html
+++ b/fragments/entities/caliper-entity-frame.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-group.html
+++ b/fragments/entities/caliper-entity-group.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-highlightannotation.html
+++ b/fragments/entities/caliper-entity-highlightannotation.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-imageobject.html
+++ b/fragments/entities/caliper-entity-imageobject.html
@@ -16,7 +16,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-learningobjective.html
+++ b/fragments/entities/caliper-entity-learningobjective.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-likertscale.html
+++ b/fragments/entities/caliper-entity-likertscale.html
@@ -16,7 +16,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-link.html
+++ b/fragments/entities/caliper-entity-link.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-ltilink.html
+++ b/fragments/entities/caliper-entity-ltilink.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-ltisession.html
+++ b/fragments/entities/caliper-entity-ltisession.html
@@ -15,7 +15,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-medialocation.html
+++ b/fragments/entities/caliper-entity-medialocation.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-mediaobject.html
+++ b/fragments/entities/caliper-entity-mediaobject.html
@@ -24,7 +24,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-membership.html
+++ b/fragments/entities/caliper-entity-membership.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-message.html
+++ b/fragments/entities/caliper-entity-message.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-multiplechoiceresponse.html
+++ b/fragments/entities/caliper-entity-multiplechoiceresponse.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-multipleresponseresponse.html
+++ b/fragments/entities/caliper-entity-multipleresponseresponse.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-multiselectquestion.html
+++ b/fragments/entities/caliper-entity-multiselectquestion.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-multiselectresponse.html
+++ b/fragments/entities/caliper-entity-multiselectresponse.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-multiselectscale.html
+++ b/fragments/entities/caliper-entity-multiselectscale.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-numericscale.html
+++ b/fragments/entities/caliper-entity-numericscale.html
@@ -18,7 +18,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-openendedquestion.html
+++ b/fragments/entities/caliper-entity-openendedquestion.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-openendedresponse.html
+++ b/fragments/entities/caliper-entity-openendedresponse.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-organization.html
+++ b/fragments/entities/caliper-entity-organization.html
@@ -25,7 +25,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-page.html
+++ b/fragments/entities/caliper-entity-page.html
@@ -15,7 +15,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-person.html
+++ b/fragments/entities/caliper-entity-person.html
@@ -16,7 +16,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-query.html
+++ b/fragments/entities/caliper-entity-query.html
@@ -17,7 +17,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>
@@ -55,7 +55,7 @@
         >Entity</a> | <a href=
             "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>The <code>Entity</code>, typically a <code>DigitalResource</code> or
+        <td>The <a href="#Entity">Entity</a>, typically a <code>DigitalResource</code> or
             <code>SoftwareApplication</code>, that is the target of the <code>Query</code>. The
             <code>resourceSearched</code> value MUST be expressed either as an object or as a
             string corresponding to the resources's IRI.

--- a/fragments/entities/caliper-entity-question.html
+++ b/fragments/entities/caliper-entity-question.html
@@ -23,7 +23,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-questionnaire.html
+++ b/fragments/entities/caliper-entity-questionnaire.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-questionnaireitem.html
+++ b/fragments/entities/caliper-entity-questionnaireitem.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-rating.html
+++ b/fragments/entities/caliper-entity-rating.html
@@ -1,5 +1,5 @@
 <h3>Rating</h3>
-<p>A Caliper <code>Rating</code> models quantitative reactions to an <code>Entity</code>.</p>
+<p>A Caliper <code>Rating</code> models quantitative reactions to an <a href="#Entity">Entity</a>.</p>
 <dl>
     <dt>IRI</dt>
     <dd><a href="https://purl.imsglobal.org/caliper/Rating">https://purl.imsglobal.org/caliper/Rating</a></dd>
@@ -15,7 +15,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>
@@ -52,7 +52,7 @@
         >Entity</a> | <a href=
             "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>The <code>Entity</code> which received the rating. The <code>rated</code> value MUST be expressed either
+        <td>The <a href="#Entity">Entity</a> which received the rating. The <code>rated</code> value MUST be expressed either
             as an object or as a string corresponding to the rated object's IRI.
         </td>
         <td>Optional</td>

--- a/fragments/entities/caliper-entity-ratingscalequestion.html
+++ b/fragments/entities/caliper-entity-ratingscalequestion.html
@@ -17,7 +17,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-ratingscaleresponse.html
+++ b/fragments/entities/caliper-entity-ratingscaleresponse.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-response.html
+++ b/fragments/entities/caliper-entity-response.html
@@ -31,7 +31,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-result.html
+++ b/fragments/entities/caliper-entity-result.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-scale.html
+++ b/fragments/entities/caliper-entity-scale.html
@@ -22,7 +22,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-score.html
+++ b/fragments/entities/caliper-entity-score.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-searchresponse.html
+++ b/fragments/entities/caliper-entity-searchresponse.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>
@@ -58,7 +58,7 @@
         >Entity</a> | <a href=
             "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>The <code>Entity</code>, typically a <code>DigitalResource</code> or
+        <td>The <a href="#Entity">Entity</a>, typically a <code>DigitalResource</code> or
             <code>SoftwareApplication</code>, that is the target of the search. The
             <code>resourceSearched</code> value MUST be expressed either as an object or as a
             string corresponding to the resources's IRI.

--- a/fragments/entities/caliper-entity-selecttextresponse.html
+++ b/fragments/entities/caliper-entity-selecttextresponse.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-session.html
+++ b/fragments/entities/caliper-entity-session.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-sharedannotation.html
+++ b/fragments/entities/caliper-entity-sharedannotation.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-softwareapplication.html
+++ b/fragments/entities/caliper-entity-softwareapplication.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-survey.html
+++ b/fragments/entities/caliper-entity-survey.html
@@ -17,7 +17,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-surveyinvitation.html
+++ b/fragments/entities/caliper-entity-surveyinvitation.html
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-tagannotation.html
+++ b/fragments/entities/caliper-entity-tagannotation.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-thread.html
+++ b/fragments/entities/caliper-entity-thread.html
@@ -16,7 +16,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-truefalseresponse.html
+++ b/fragments/entities/caliper-entity-truefalseresponse.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-videoobject.html
+++ b/fragments/entities/caliper-entity-videoobject.html
@@ -15,7 +15,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/entities/caliper-entity-webpage.html
+++ b/fragments/entities/caliper-entity-webpage.html
@@ -16,7 +16,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-annotation.html
+++ b/fragments/events/caliper-event-annotation.html
@@ -22,7 +22,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-assessment.html
+++ b/fragments/events/caliper-event-assessment.html
@@ -19,7 +19,7 @@
         restrictions are described below:</dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-assessmentitem.html
+++ b/fragments/events/caliper-event-assessmentitem.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-assignable.html
+++ b/fragments/events/caliper-event-assignable.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-event.html
+++ b/fragments/events/caliper-event-event.html
@@ -2,18 +2,18 @@
 
 <img height="100%" width="100%" src="assets/caliper-event_model_no_title-v1p2.png" alt="Caliper Event">
 
-<p>A Caliper <code>Event</code> is a generic type that describes the relationship established between an
-    <code>action</code> and an <code>object</code>, formed as a result of a purposeful
-    <a href="#actions">action</a> undertaken by the <code>action</code> at a particular moment in time and within a
-    given learning context. The <code>Event</code> properties <code>action</code>, <code>action</code> and
+<p>A Caliper <a href="#Event">Event</a> is a generic type that describes the relationship established between an
+    <code>actor</code> and an <code>object</code>, formed as a result of a purposeful
+    <a href="#actions">action</a> undertaken by the <code>actor</code> at a particular moment in time and within a
+    given learning context. The <a href="#Event">Event</a> properties <code>actor</code>, <code>action</code> and
     <code>object</code> form a compact data structure that resembles an <a href="#rdf">RDF</a> triple linking a subject
     to an object via a predicate. A learner starting an assessment, annotating a reading, pausing a video, or
     posting a message to a forum, are examples of learning activities that Caliper models as events.</p>
 
-<p>Caliper defines a number of <code>Event</code> subtypes, each scoped to a particular activity domain and
+<p>Caliper defines a number of <a href="#Event">Event</a> subtypes, each scoped to a particular activity domain and
     distinguishable by a <code>type</code> attribute. The <code>type</code> value is a string that MUST match the
-    <a href="#termDef">Term</a> specified for the <code>Event</code> by the Caliper information model
-    (e.g. "MessageEvent"). Each <code>Event</code> instance is assigned a 128-bit long universally unique
+    <a href="#termDef">Term</a> specified for the <a href="#Event">Event</a> by the Caliper information model
+    (e.g. "MessageEvent"). Each <a href="#Event">Event</a> instance is assigned a 128-bit long universally unique
     identifier (UUID) formatted as a <a href="#urnDef">URN</a> per <a href="#rfc4122">RFC 4122</a>, which describes
     a <a href="#urnDef">URN</a> namespace for <a href="#uuidDef">UUIDs</a>.</p>
 
@@ -24,11 +24,6 @@
     annotating a piece of digital content and producing an <a href="#Annotation">Annotation</a> is one such example.
     An <code>extensions</code> property is also provided so that implementers can add custom attributes not described
     by the model.</p>
-
-<p>Considered as a data structure an <code>Event</code> constitutes an unordered set of key:value pairs that is
-    semi-structured by design. Optional attributes can be ignored when describing an <code>Event</code>. An
-    <a href="#Entity">Entity</a> participating in an <code>Event</code> can be represented as an object or as a
-    string that corresponds to the <a href="#iriDef">IRI</a> defined for the <a href="#Entity">Entity</a>.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -60,16 +55,29 @@
         <a href="#ViewEvent">ViewEvent</a>
     </dd>
     <dt>Properties</dt>
-    <dd>The base set of <code>Event</code> properties or attributes is listed below. Each property MUST be
-        referenced only once. The <code>id</code>, <code>type</code>, <code>action</code>, <code>action</code>,
-        <code>object</code> and <code>eventTime</code> properties are required; all other properties are optional.
-        Custom attributes not described by the model MAY be included but MUST be added to the <code>extensions</code>
-        property as a map of key:value pairs. Properties with a value of *null* or empty SHOULD be excluded prior
-        to serialization.
+    <dd>The base set of <a href="#Event">Event</a> properties or attributes is listed below.
+        Considered as a data structure an <a href="#Event">Event</a> constitutes an unordered set
+        of key:value pairs that is semi-structured by design. Optional attributes can be ignored
+        when describing an <a href="#Event">Event</a>. An <a href="#Entity">Entity</a> participating
+        in an <a href="#Event">Event</a> can be represented as an object or as a string that
+        corresponds to the <a href="#iriDef">IRI</a> defined for the <a href="#Entity">Entity</a>.
+        Each property MUST be referenced only once. The <code>id</code>, <code>type</code>,
+        <code>action</code>, <code>action</code>, <code>object</code> and <code>eventTime</code>
+        properties are required; all other properties are optional. Custom attributes not
+        described by the model MAY be included but MUST be added to the <code>extensions</code>
+        property as a map of key:value pairs. Properties with a value of <em>null</em> or
+        empty SHOULD be excluded prior to serialization.
     </dd>
 </dl>
 
-<table class="data">
+<p class="note" title="Referencing an Event's governing profile">Although each
+    <a href="#Event">Event's</a> <code>profile</code> property is considered optional (in order
+    to ensure backwards compatibility) <a href="#sensor">Sensors</a> SHOULD specify for each
+    <a href="#Event">Event</a> created the relevant <code>profile</code> string value in
+    order to inform consumers which profile governs the construction and interpretation of
+    the <a href="#Event">Event</a>.</p>
+
+<table>
     <thead>
     <tr>
         <th>Property</th>
@@ -82,7 +90,7 @@
     <tr>
         <td>id</td>
         <td><a href="#uuidDef">UUID</a></td>
-        <td>The emitting application MUST provision the <code>Event</code> with a <a href="#uuidDef">UUID</a>.
+        <td>The emitting application MUST provision the <a href="#Event">Event</a> with a <a href="#uuidDef">UUID</a>.
             A version 4 <a href="#uuidDef">UUID</a> SHOULD be generated. The UUID MUST be expressed as a
             <a href="#urnDef">URN</a> using the form "urn:uuid:&lt<a href="uuidRef">UUID</a>&gt" per
             <a href="#rfc4122">RFC 4122</a>.</td>
@@ -91,9 +99,9 @@
     <tr>
         <td>type</td>
         <td><a href="#termDef">Term</a></td>
-        <td>A string value corresponding to the <a href="#termDef">Term</a> defined for the <code>Event</code>
+        <td>A string value corresponding to the <a href="#termDef">Term</a> defined for the <a href="#Event">Event</a>
             in the external IMS Caliper JSON-LD <a href="http://purl.imsglobal.org/ctx/caliper/v1p2">context</a>document.
-            For a generic <code>Event</code> set the <code>type</code> to the string value <em>Event</em>.
+            For a generic <a href="#Event">Event</a> set the <code>type</code> to the string value <em>Event</em>.
             If a subtype of <a href="#Entity">Entity</a> is created, set the <code>type</code> to the
             <a href="#termDef">Term</a> corresponding to the subtype utilized, e.g., <em>NavigationEvent</em>.</td>
         <td>Required</td>
@@ -102,18 +110,18 @@
         <td>profile</td>
         <td><a href="#termDef">Term</a></td>
         <td>A string value corresponding to the <a href="#termDef">Term</a> value defined for the
-            <a href="#profileDef">Profile</a> that governs the rules of interpretation for this <code>Event</code>.
+            <a href="#profileDef">Profile</a> that governs the rules of interpretation for this <a href="#Event">Event</a>.
             The range of <a href="#profileDef">Profile</a> values is limited to the set of profiles described in this
             specification and any profile extension specifications extending this specification. Only one
-            <code>profile</code> [Term](#termDef) value may be specified per <code>Event</code>. For a generic
-            <code>Event</code> set the <code>profile</code> property value to the string term
+            <code>profile</code> [Term](#termDef) value may be specified per <a href="#Event">Event</a>. For a generic
+            <a href="#Event">Event</a> set the <code>profile</code> property value to the string term
             <em>GeneralProfile</em>.</td>
         <td>Optional</td>
     </tr>
     <tr>
         <td>actor</td>
         <td><a href="#Agent">Agent</a> | <a href="#iriDef">IRI</a></td>
-        <td>The <a href="#Agent">Agent</a> who initiated the <code>Event</code>, typically though not always a
+        <td>The <a href="#Agent">Agent</a> who initiated the <a href="#Event">Event</a>, typically though not always a
             <a href="#Person">Person</a>. The <code>action</code> value MUST be expressed either as an object or as a
             string corresponding to the actor's <a href="#iriDef">IRI</a>.</td>
         <td>Required</td>
@@ -123,8 +131,8 @@
         <td><a href="#termDef">Term</a></td>
         <td>The action or predicate that binds the actor or subject to the object. The <code>action</code> range is
             limited to the set of <a href="#actions">actions</a> described in this specification or associated profiles
-            and may be further constrained by the chosen <code>Event</code> type. Only one <code>action</code>
-            <a href="#termDef">Term</a> may be specified per <code>Event</code>.</td>
+            and may be further constrained by the chosen <a href="#Event">Event</a> type. Only one <code>action</code>
+            <a href="#termDef">Term</a> may be specified per <a href="#Event">Event</a>.</td>
         <td>Required</td>
     </tr>
     <tr>
@@ -139,7 +147,7 @@
         <td>eventTime</td>
         <td>DateTime</td>
         <td>An ISO 8601 date and time value expressed with millisecond precision that indicates when the
-            <code>Event</code> occurred. The value MUST be expressed using the format YYYY-MM-DDTHH:mm:ss.SSSZ
+            <a href="#Event">Event</a> occurred. The value MUST be expressed using the format YYYY-MM-DDTHH:mm:ss.SSSZ
             set to UTC with no offset specified.</td>
         <td>Required</td>
     </tr>
@@ -202,7 +210,7 @@
     <tr>
         <td>federatedSession</td>
         <td><a href="#FederatedSession">federatedSession</a> | <a href="#iriDef">IRI</a></td>
-        <td>If the <code>Event</code> occurs within the context of an <a href="#ltiDef">LTI</a> platform launch,
+        <td>If the <a href="#Event">Event</a> occurs within the context of an <a href="#ltiDef">LTI</a> platform launch,
             the tool's <a href="#LtiSession">LtiSession</a> MAY be referenced. The <code>federatedSession</code>
             value MUST be expressed either as an object or as a string corresponding to the federated session's
             <a href="#iriDef">IRI</a>.</td>
@@ -212,17 +220,8 @@
         <td>extensions</td>
         <td>Object</td>
         <td>A map of additional attributes not defined by the model MAY be specified for a more concise
-            representation of the <code>Event</code>.</td>
+            representation of the <a href="#Event">Event</a>.</td>
         <td>Optional</td>
     </tr>
     </tbody>
 </table>
-
-<div class="practice">
-    <p class="practicedesc">
-        <span class="practicelab">Reference the governing profile</span> Although <code>Event.profile</code> is
-        considered optional (in order to ensure backwards compatibility) <a href="#sensor">Sensors</a> SHOULD specify
-        for each <code>Event</code> the relevant <code>profile</code> string value in order to inform consumers
-        which profile governs the construction and interpretation of the <code>Event</code>.
-    </p>
-</div>

--- a/fragments/events/caliper-event-feedback.html
+++ b/fragments/events/caliper-event-feedback.html
@@ -5,7 +5,7 @@
 <img height="100%" width="100%" src="assets/caliper-feedback_event_commented-v1p2.png" alt="Feedback Event Commented">
 
 <p>A Caliper <code>FeedbackEvent</code> models a <code>Person</code> providing informal feedback
-    on an <code>Entity</code>, typically a <code>DigitalResource</code> or another <code>Person</code>.
+    on an <a href="#Entity">Entity</a>, typically a <code>DigitalResource</code> or another <code>Person</code>.
 </p>
 
 <dl>
@@ -23,7 +23,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>
@@ -71,7 +71,7 @@
         >Entity</a> | <a href=
              "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>The <code>Entity</code> that is the target of the feedback. The <code>object</code> value MUST
+        <td>The <a href="#Entity">Entity</a> that is the target of the feedback. The <code>object</code> value MUST
             be expressed either as an object or as a string corresponding to the resource's IRI.
         </td>
         <td>Required</td>

--- a/fragments/events/caliper-event-grade.html
+++ b/fragments/events/caliper-event-grade.html
@@ -22,7 +22,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-media.html
+++ b/fragments/events/caliper-event-media.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-message.html
+++ b/fragments/events/caliper-event-message.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-navigation-survey.html
+++ b/fragments/events/caliper-event-navigation-survey.html
@@ -22,7 +22,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-navigation.html
+++ b/fragments/events/caliper-event-navigation.html
@@ -19,7 +19,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-questionnaire.html
+++ b/fragments/events/caliper-event-questionnaire.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-questionnaireitem.html
+++ b/fragments/events/caliper-event-questionnaireitem.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-resourcemanagement.html
+++ b/fragments/events/caliper-event-resourcemanagement.html
@@ -3,7 +3,7 @@
 <img height="100%" width="100%" src="assets/caliper-resource_management_event_created-v1p2.png"
      alt="ResourceManagementEvent">
 
-<p>A Caliper <code>ResourceManagementEvent</code> models a <code>Person</code> managing an <code>Entity</code>.</p>
+<p>A Caliper <code>ResourceManagementEvent</code> models a <code>Person</code> managing an <a href="#Entity">Entity</a>.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -20,7 +20,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-search.html
+++ b/fragments/events/caliper-event-search.html
@@ -23,7 +23,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-session.html
+++ b/fragments/events/caliper-event-session.html
@@ -23,7 +23,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-survey.html
+++ b/fragments/events/caliper-event-survey.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-surveyinvitation.html
+++ b/fragments/events/caliper-event-surveyinvitation.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-thread.html
+++ b/fragments/events/caliper-event-thread.html
@@ -22,7 +22,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-toollaunch.html
+++ b/fragments/events/caliper-event-toollaunch.html
@@ -27,7 +27,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-tooluse.html
+++ b/fragments/events/caliper-event-tooluse.html
@@ -21,7 +21,7 @@
         described below:
     </dd>
 </dl>
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-view-questionnaire.html
+++ b/fragments/events/caliper-event-view-questionnaire.html
@@ -23,7 +23,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/events/caliper-event-view.html
+++ b/fragments/events/caliper-event-view.html
@@ -21,7 +21,7 @@
     </dd>
 </dl>
 
-<table class="data">
+<table>
     <thead>
     <tr>
         <th>Property</th>

--- a/fragments/profiles/caliper-profile-annotation.html
+++ b/fragments/profiles/caliper-profile-annotation.html
@@ -16,18 +16,19 @@
     sharing a resource, tagging a document, and viewing an annotation are modeled. The generated
     <a href="#Annotation">Annotation</a> is also described and is subtyped for greater type specificity.</p>
 
-<p>The Annotation Profile supports the following user stories:</p>
+<p>The Annotation Profile supports the following user stories:
 
-<ul>
-    <li>As an instructor, I would like to know which students are generating annotations.</li>
-    <li>As an instructor, I would like to know what content is most often annotated.</li>
-    <li>As an instructor, I would like to know what types of annotations are being created.</li>
-    <li>As an instructor, I would like to know which segments of text are being highlighted.</li>
-    <li>As an instructor, I would like to know what tags are being used.</li>
-    <li>As an instructor, I would like to know what notes are being added.</li>
-</ul>
+    <ul>
+        <li>As an instructor, I would like to know which students are generating annotations.</li>
+        <li>As an instructor, I would like to know what content is most often annotated.</li>
+        <li>As an instructor, I would like to know what types of annotations are being created.</li>
+        <li>As an instructor, I would like to know which segments of text are being highlighted.</li>
+        <li>As an instructor, I would like to know what tags are being used.</li>
+        <li>As an instructor, I would like to know what notes are being added.</li>
+    </ul>
+</p>
 
-<p>As an example, instructors can use the places where students are making notes in the course material
+<p class="note" title='Note taking analysis'>As an example, instructors can use the places where students are making notes in the course material
     to determine whether they have the right idea about which material should be highlighted. In addition,
     if there are students who are asking questions or making notes indicating confusion about a particular
     piece of content, this can also inform the instructor about the suitability or quality of the material
@@ -38,7 +39,7 @@
     <p>The Annotation Profile defines an <a href="#AnnotationEvent">AnnotationEvent</a> for describing the
         annotation of resources. Four actions are described:
 
-    <table class="data">
+    <table>
         <thead>
             <tr>
                 <th>Event</th>

--- a/fragments/profiles/caliper-profile-assessment.html
+++ b/fragments/profiles/caliper-profile-assessment.html
@@ -34,7 +34,7 @@
     <a href="#NavigationEvent">NavigationEvent</a>, and <a href="#ViewEvent">ViewEvent</a> for
     describing learner interactions with tests and questions. Ten actions are described:</p>
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-assignable.html
+++ b/fragments/profiles/caliper-profile-assignable.html
@@ -31,7 +31,7 @@
     <a href="#NavigationEvent">NavigationEvent</a>, and <a href="#ViewEvent">ViewEvent</a> for
     describing learner interactions with assignments. Eight actions are described:</p>
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-feedback.html
+++ b/fragments/profiles/caliper-profile-feedback.html
@@ -30,7 +30,7 @@
 <p>The Feedback Profile defines a <a href="#FeedbackEvent">FeedbackEvent</a> for ranking resources and recording
     comments. Two actions are described:
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-forum.html
+++ b/fragments/profiles/caliper-profile-forum.html
@@ -34,7 +34,7 @@
     <a href="#Thread">Thread</a>, and <a href="#Message">Message</a> interactions. Nine actions are described:
 </p>
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-general.html
+++ b/fragments/profiles/caliper-profile-general.html
@@ -1,9 +1,9 @@
 <h3>General Profile</h3>
 
-<aside class="warning">Use of the General Profile is strictly limited to describing interactions not modeled by the
+<p class="note" title="General Profile restrictions">Use of the General Profile is strictly limited to describing interactions not modeled by the
     current set of Caliper Profiles. Only the generic <a href="#Event">Event</a> may be utilized to describe such
     activities.
-</aside>
+</p>
 
 <img height="100%" width="100%" src="assets/caliper-profile_general.png" alt="General Profile">
 
@@ -19,7 +19,7 @@
     this specification can be used to describe the interaction between the <code>actor</code> and the
     <code>object.</code></p>
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-grading.html
+++ b/fragments/profiles/caliper-profile-grading.html
@@ -31,7 +31,7 @@
 <p>The Grading Profile defines a <a href="#GradeEvent">GradeEvent</a> for describing the scoring of assignments
     and a <a href="#ViewEvent">ViewEvent</a> for viewing results. Two actions are described:
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-media.html
+++ b/fragments/profiles/caliper-profile-media.html
@@ -18,12 +18,13 @@
     <a href="#mediaObject">MediaObject</a>. A <a href="#mediaLocation">MediaLocation</a> entity is also
     provided in order to represent the current location in an audio or video stream.</p>
 
-<p>As an example of how this profile could be used, consider the following scenario: an instructor has
-    decided to incorporate a video player into their course.  The video content may or may not be launched
-    via <a href="#ltiDef">LTI</a> from the Learning Management System (LMS). Since the video player tool
-    is instrumented to emit activity data via Caliper, the instructor will be able to collect useful
-    information about student viewing behavior. In addition, he will be able to compare this data along
-    with other relevant information in the LMS, such as assignment and quiz results.</p>
+<p class="note" title='Collecting video interaction data'>As an example of how this profile could be used, consider the following scenario: an
+    instructor has decided to incorporate a video player into their course. The video content
+    may or may not be launched via <a href="#ltiDef">LTI</a> from the Learning Management
+    System (LMS). Since the video player tool is instrumented to emit activity data via Caliper,
+    the instructor will be able to collect useful information about student viewing behavior.
+    In addition, she will be able to compare this data along with other relevant information
+    in the LMS, such as assignment and quiz results.</p>
 
 <p>The Media Profile supports the following user stories:</p>
 
@@ -41,7 +42,7 @@
     <a href="#AudioObject">AudioObject</a>, <a href="#ImageObject">ImageObject</a>, or
     <a href="#VideoObject">VideoObject</a>. Twenty-one actions are described:
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-reading.html
+++ b/fragments/profiles/caliper-profile-reading.html
@@ -33,7 +33,7 @@
 <p>The Reading Profile defines a <a href="#NavigationEvent">NavigationEvent</a> for traversing resources and a
     <a href="#ViewEvent">ViewEvent</a> for viewing content. Two actions are described:
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-resourcemanagement.html
+++ b/fragments/profiles/caliper-profile-resourcemanagement.html
@@ -31,7 +31,7 @@
     Fourteen actions are described:
 </p>
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-search.html
+++ b/fragments/profiles/caliper-profile-search.html
@@ -17,7 +17,7 @@
     entity can be employed to describe the <a href="#Query">Query</a> submitted by a user as well as any
     <code>searchResults</code> returned as a result of the search.</p>
 
-<p>When the Search Profile is used in conjunction with the <a href="#profile-reading">Reading Profile</a>, a learner's
+<p class="note" title='Combining search data with navigation and viewing data'>When the Search Profile is used in conjunction with the <a href="#profile-reading">Reading Profile</a>, a learner's
     navigation, search, and viewing behavior can be combined to provide a richer picture of learner interactions with
     digital resources.</p>
 
@@ -32,7 +32,7 @@
 <p>The Search Profile defines a <a href="#SearchEvent">SearchEvent</a> for querying resources. A single
     action is described:
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-session.html
+++ b/fragments/profiles/caliper-profile-session.html
@@ -16,7 +16,7 @@
     <a href="#softwareApplication">SoftwareApplication</a>. A <a href="#Session">Session</a> entity is
     described for representing the user session.</p>
 
-<p>The session profile can facilitate the capture of data about who is logging into the learning
+<p>The Session Profile can facilitate the capture of data about who is logging into the learning
     environment, and more importantly, which students are not logging in.</p>
 
 <p>The Session Profile supports the following user stories:</p>
@@ -29,7 +29,7 @@
 <p>The Session Profile defines a <a href="#SessionEvent">SessionEvent</a> for recording application log in, log out,
     and time out activity.</p>
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>
@@ -91,6 +91,3 @@ When constructing a <a href="#SessionEvent">SessionEvent</a> the following rules
     <li>A map of additional <code>extensions</code> MAY be included but beware the inherent interoperability
         limitations of transmitting data not described by the model.</li>
 </ul>
-
-
-<a href="#AggregateMeasureCollection">AggregateMeasureCollection</a>

--- a/fragments/profiles/caliper-profile-survey.html
+++ b/fragments/profiles/caliper-profile-survey.html
@@ -26,10 +26,9 @@
     areas in teaching and learning can be improved to enhance students’ learning experience and performance.
     The Caliper Survey Profile expands the pool of Caliper-instrumented learning data profiles to enhance the learning
     analytics across the analytics continuum &mdash; descriptive, diagnostic, predictive, and prescriptive &mdash; by
-    allowing to incorporate student voices to make learning analytics more robust.</p>
+    allowing student voices to be incorporated in order to make learning analytics more robust.</p>
 
-<p>The Survey Profile supports the following user stories: (...TO DO  Compare user stories to bulleted list from
-    standalone profile; each story was derived from one bullet in the list; order has been maintained.)</p>
+<p>The Survey Profile supports the following user stories:</p>
 
 <ul>
     <li>As an instructor, I would like to analyze survey response rates and responses to gauge the engagement level of
@@ -52,7 +51,7 @@
     <a href="#QuestionnaireItemEvent">QuestionnaireItemEvent</a>, <a href="#NavigationEvent">NavigationEvent</a>, and
     <a href="#ViewEvent">ViewEvent</a> for describing survey-related activities. Twelve actions are described:
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-toollaunch.html
+++ b/fragments/profiles/caliper-profile-toollaunch.html
@@ -25,7 +25,8 @@
     a measure of whether the user actually interacted with the tool in a manner that the application determines to be
     its “intended use for learning”.</p>
 
-<p>In certain deployment contexts, using both the Tool Launch and the Tool Use Profiles may be advantageous, as, for
+<p class="note" title="Using the Tool Launch and Tool Use Profiles together">In certain deployment contexts,
+    using both the Tool Launch and the Tool Use Profiles may be advantageous, as, for
     example, it allows the tracking of the number of tool launches that do <em>not</em> lead to interactions
     corresponding to the "intended use for learning".</p>
 
@@ -46,7 +47,7 @@
     <a href="#Person">Person</a> launching a tool from a platform or returning to a platform after completing a
     tool session. Two actions are described:
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>

--- a/fragments/profiles/caliper-profile-tooluse.html
+++ b/fragments/profiles/caliper-profile-tooluse.html
@@ -42,15 +42,14 @@
     <a href="#Person">Person</a> using a learning tool in a way that the tool's creators have
     determined is an indication of a learning interaction. A single action is described.
 
-<p class="note" title="Expressing learner progress using Aggregate Measures">
-    A <a href="#ToolUseEvent">ToolUseEvent</a> MAY also be used to communicate learner progress by referencing a
-    collection of one or more <a href="#AggregateMeasure">AggregateMeasure</a> entities. A <a href="#sensor">Sensor</a>
-    that needs to report such information should assign an
+<p class="note" title="Expressing learner progress using aggregate measures">A
+    <a href="#ToolUseEvent">ToolUseEvent</a> MAY also be used to communicate learner progress by
+    referencing a collection of one or more <a href="#AggregateMeasure">AggregateMeasure</a>
+    entities. A <a href="#sensor">Sensor</a> that needs to report such information should assign an
     <a href="#entity-AggregateMeasureCollection">AggregateMeasureCollection</a>
-    as the <code>generated</code> value for any reported aggregate metric information.
-<p>
+    as the <code>generated</code> value for any reported aggregate metric information.</p>
 
-<table class="data">
+<table>
     <thead>
         <tr>
             <th>Event</th>


### PR DESCRIPTION
This PR adds the first set of note highlights to the spec as well as removes the class="data" attribute from `<table>` tags in order to fix a table alignment issue introduced by respec CSS changes.

Example note:
```
<p class="note" title="Authorization header">A <a href="#sensor">Sensor</a> SHOULD
                also set the <code>Authorization</code> request header field using
                the "Bearer" authentication scheme described in <a href="#rfc6750">RFC 6750</a>,
                <a href="https://tools.ietf.org/html/rfc6750#section-2">Section 2.1</a>.
                The <code>b64token</code> authorization credential sent by a
                <a href="#sensor">Sensor</a> MUST be one the
                <a href="#endpoint">Endpoint</a> can validate although the credential MAY be
                opaque to the emitting <a href="#sensor">Sensor</a> itself.</p>
```
