### PR TITLE
Editing action section and fragments in caliper-spec-v1p2.html

### DIFF
--- a/caliper-spec-v1p2.html
+++ b/caliper-spec-v1p2.html
@@ -1608,17 +1608,21 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
     <section id="actions" class="appendix">
         <h2>Actions</h2>
 
-        <p>Caliper includes a vocabulary of actions for describing learning interactions. Each action <a href="#termDef">Term</a>
-            is based on the past-tense form of an English (en-US) verb. An action <a href="#termDef">Term</a> can also
-            indicate a change in a particular characteristic of the <code>object</code> (e.g., resolution, size, speed,
-            volume). Each action <a href="#termDef">Term</a> is mapped to a persistent <a href="iriDef">IRI</a> listed
-            in the external IMS Caliper JSON-LD <a href="http://purl.imsglobal.org/ctx/caliper/v1p2">context</a>. Each
-            action is also linked to a brief definition ("gloss") derived in whole or in part from Princeton
-            University's WordNet&reg; project in order to eliminate ambiguity and aid natural language processing.</p>
+        <p>Caliper includes a vocabulary of actions for describing learning interactions. Each
+            action <a href="#termDef">Term</a> is based on the past-tense form of an English (en-US)
+            verb. An action <a href="#termDef">Term</a> can also indicate a change in a particular
+            characteristic of the <code>object</code> (e.g., resolution, size, speed, volume). Each
+            action <a href="#termDef">Term</a> is mapped to a persistent <a href="iriDef">IRI</a>
+            listed in the external IMS Caliper JSON-LD
+            <a href="http://purl.imsglobal.org/ctx/caliper/v1p2">context</a>. Each action is also
+            linked to one or more brief definitions ("glosses") derived in whole or in part from
+            Princeton University's WordNet&reg; project or the Wiktionary project in order to
+            eliminate ambiguity and aid natural language processing.</p>
 
-        <p>Each Caliper <a href="#Event">Event</a> type supports one or more of the actions listed below.
-            The <a href="#Event">Event</a> <code>action</code> property string value MUST be set to the appropriate
-            <a href="termDef">Term</a>. Only one action may be specified per <a href="#Event">Event</a>.</p>
+        <p>Each Caliper <a href="#Event">Event</a> type supports one or more of the actions listed
+            below. The <a href="#Event">Event</a> <code>action</code> property string value MUST be
+            set to the appropriate <a href="termDef">Term</a>. Only one action may be specified per
+            <a href="#Event">Event</a>.</p>
 
         <section id="action-abandoned" data-include="fragments/actions/caliper-action-abandoned.html"></section>
         <section id="action-accepted" data-include="fragments/actions/caliper-action-accepted.html"></section>

--- a/fragments/actions/caliper-action-abandoned.html
+++ b/fragments/actions/caliper-action-abandoned.html
@@ -1,6 +1,6 @@
 <h3>Abandoned</h3>
-<p>The <em>Abandoned</em> action signals that some <a href="#Entity">Entity</a> has been left behind or
-    unfinished. ... TO DO</p>
+<p>The <em>Abandoned</em> action signals that some <a href="#Entity">Entity</a> was left behind or
+    unfinished.</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-accepted.html
+++ b/fragments/actions/caliper-action-accepted.html
@@ -1,6 +1,6 @@
 <h3>Accepted</h3>
-<p>The <em>Accepted</em> action signals that an affirmative reply has been given. Inverse of
-    <a href="#action-declined">Declined</a>. ...TO DO
+<p>The <em>Accepted</em> action signals that an affirmative reply was given with regard to some
+    <a href="#Entity">Entity</a>. Inverse of <a href="#action-declined">Declined</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-activated.html
+++ b/fragments/actions/caliper-action-activated.html
@@ -1,6 +1,6 @@
 <h3>Activated</h3>
-<p>The <em>Activated</em> action signals that some <a href="#Entity">Entity</a> has been made active. Inverse of
-    <a href="#action-deactivated">Deactivated</a>. ...TO DO
+<p>The <em>Activated</em> action signals that some <a href="#Entity">Entity</a> was made active or
+    put to work. Inverse of <a href="#action-deactivated">Deactivated</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-added.html
+++ b/fragments/actions/caliper-action-added.html
@@ -1,6 +1,7 @@
 <h3>Added</h3>
-<p>The <em>Added</em> action signals the addition of some <a href="#Entity">Entity</a>. Inverse of
-    <a href="#action-removed">Removed</a>. ...TO DO
+<p>The <em>Added</em> action signals that some <a href="#Entity">Entity</a> was combined with
+    or appended to some other <a href="#Entity">Entity</a> or entities. Inverse of
+    <a href="#action-removed">Removed</a>.
 </p>
 
 <dl>
@@ -9,8 +10,9 @@
     <dt>Term</dt>
     <dd>Added</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00182551-v">add</a> - <em>make an addition (to); join
-        or combine or unite with others; increase the quality, quantity, size or scope of</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00182551-v">add</a> - <em>make an
+        addition (to); join or combine or unite with others; increase the quality, quantity, size or
+        scope of</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a></dd>

--- a/fragments/actions/caliper-action-archived.html
+++ b/fragments/actions/caliper-action-archived.html
@@ -1,5 +1,7 @@
 <h3>Archived</h3>
-<p>The <em>Archived</em> action signals that an <a href="#Entity">Entity</a> has been put into long-term storage.</p>
+<p>The <em>Archived</em> action signals that an <a href="#Entity">Entity</a> was put into long-term
+    storage.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -11,5 +13,7 @@
         <em>put into an archive</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd><a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-attached.html
+++ b/fragments/actions/caliper-action-attached.html
@@ -1,6 +1,6 @@
 <h3>Attached</h3>
-<p>The <em>Attached</em> action signals that some <a href="#Entity">Entity</a> has been attached to some other
-    <a href="#Entity">Entity</a>. ... TO DO</p>
+<p>The <em>Attached</em> action signals that some <a href="#Entity">Entity</a> was affixed to
+    or included with some other <a href="#Entity">Entity</a>.</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-bookmarked.html
+++ b/fragments/actions/caliper-action-bookmarked.html
@@ -1,6 +1,6 @@
 <h3>Bookmarked</h3>
-<p>The <em>Bookmarked</em> action signals that some location of interest within a
-    <a href="#DigitalResource">DigitalResource</a> has been labeled or flagged. ...TO DO
+<p>The <em>Bookmarked</em> action signals that some location of interest within an
+    <a href="#Entity">Entity</a> was flagged or labeled.
 </p>
 
 <dl>
@@ -10,7 +10,8 @@
     <dd>Bookmarked</dd>
     <dt>Related Gloss(es)</dt>
     <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02874508-n">bookmarker, bookmark</a> -
-        <em>a marker (a piece of paper or ribbon) placed between the pages of a book to mark the reader's place</em>
+        <em>a marker (a piece of paper or ribbon) placed between the pages of a book to mark the
+            reader's place</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AnnotationEvent">AnnotationEvent</a></dd>

--- a/fragments/actions/caliper-action-changedresolution.html
+++ b/fragments/actions/caliper-action-changedresolution.html
@@ -1,6 +1,6 @@
 <h3>ChangedResolution</h3>
-<p>The <em>ChangedResolution</em> action signals that the number of pixels per square inch on a computer-generated
-   display has been changed or adjusted. ...TO DO
+<p>The <em>ChangedResolution</em> action signals that a visual display's representation of detail
+    (measured by pixel density) was changed or adjusted.
 </p>
 
 <dl>
@@ -13,8 +13,8 @@
         <em>cause to change; make different; cause a transformation</em>
     </dd>
     <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/11526370-n">resolution</a> -
-        <em>the number of pixels per square inch on a computer-generated display; the greater the resolution, the
-            better the picture
+        <em>the number of pixels per square inch on a computer-generated display; the greater the
+            resolution, the better the picture
         </em>
     </dd>
     <dt>Supported by</dt>

--- a/fragments/actions/caliper-action-changedsize.html
+++ b/fragments/actions/caliper-action-changedsize.html
@@ -1,5 +1,6 @@
 <h3>ChangedSize</h3>
-<p>The <em>ChangedSize</em> action signals that the magnitude of some thing has changed. ...TO DO</p>
+<p>The <em>ChangedSize</em> action signals that the magnitude of some <a href="#Entity">Entity</a>
+    was modified.</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-changedspeed.html
+++ b/fragments/actions/caliper-action-changedspeed.html
@@ -1,5 +1,7 @@
 <h3>ChangedSpeed</h3>
-<p>The <em>ChangedSpeed</em> action signals an altering of the rate at at which something happens. ...TO DO</p>
+<p>The <em>ChangedSpeed</em> action signals an altering of the rate of some process associated with
+    an <a href="#Entity">Entity</a>.
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-changedvolume.html
+++ b/fragments/actions/caliper-action-changedvolume.html
@@ -1,6 +1,6 @@
 <h3>ChangedVolume</h3>
-<p>The <em>ChangedVolume</em> action signals an altering of the magnitude of sound originating from or related to some
-    <a href="#Entity">Entity</a>. ...TO DO
+<p>The <em>ChangedVolume</em> action signals an altering of the magnitude of sound originating from
+    or related to some <a href="#Entity">Entity</a>.
 </p>
 
 <dl>
@@ -9,11 +9,11 @@
     <dt>Term</dt>
     <dd>ChangedVolume</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00126072-v">modify, alter, change</a> -
-        <em>cause to change; make different; cause a transformation</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00126072-v">modify, alter, change</a>
+        - <em>cause to change; make different; cause a transformation</em>
     </dd>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/04997456-n">intensity, volume, loudness</a> -
-        <em>the magnitude of sound (usually in a specified direction)</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/04997456-n">intensity, volume,
+        loudness</a> - <em>the magnitude of sound (usually in a specified direction)</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-classified.html
+++ b/fragments/actions/caliper-action-classified.html
@@ -1,6 +1,6 @@
 <h3>Classified</h3>
-<p>The <em>Classified</em> action signals that some <a href="#Entity">Entity</a> has been placed or assigned to some
-    class, group, kind, or type. ... TO DO
+<p>The <em>Classified</em> action signals that some <a href="#Entity">Entity</a> was placed or
+    assigned to some class, group, kind, or type.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-closedpopout.html
+++ b/fragments/actions/caliper-action-closedpopout.html
@@ -1,6 +1,6 @@
 <h3>ClosedPopout</h3>
-<p>The <em>ClosedPopout</em> action signals that a video popout has been closed. Inverse of
-    <a href="#action-openedPopout">OpenedPopout</a>. ...TO DO
+<p>The <em>ClosedPopout</em> action signals that a video popout was closed. Inverse of
+    <a href="#action-openedPopout">OpenedPopout</a>.
 </p>
 
 <dl>
@@ -9,7 +9,8 @@
     <dt>Term</dt>
     <dd>ClosedPopout</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01349660-v">close, shut</a> - <em>become closed</em></dd>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01349660-v">close, shut</a> -
+        <em>become closed</em></dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-commented.html
+++ b/fragments/actions/caliper-action-commented.html
@@ -1,6 +1,6 @@
 <h3>Commented</h3>
 <p>The <em>Commented</em> action signals that qualitative feedback in the form of a
-    <a href="#Comment">Comment</a> has been provided.
+    <a href="#Comment">Comment</a> was provided.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Commented</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01060446-v">comment, point out, remark, notice</a> -
-        <em>make or write a comment on</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01060446-v">comment, point out,
+        remark, notice</a> - <em>make or write a comment on</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#FeedbackEvent">FeedbackEvent</a></dd>

--- a/fragments/actions/caliper-action-completed.html
+++ b/fragments/actions/caliper-action-completed.html
@@ -1,7 +1,8 @@
 <h3>Completed</h3>
-<p>The <em>Completed</em> action signals that an <a href="#Entity">Entity</a>, or the work or activity
-    associated with it, has been finished. ...TO DO
+<p>The <em>Completed</em> action signals that an <a href="#Entity">Entity</a>, or the work or
+    activity associated with it, was finished.
 </p>
+
 <dl>
     <dt>IRI</dt>
     <dd>https://purl.imsglobal.org/caliper/actions/Completed</dd>

--- a/fragments/actions/caliper-action-copied.html
+++ b/fragments/actions/caliper-action-copied.html
@@ -1,5 +1,5 @@
 <h3>Copied</h3>
-<p>The <em>Copied</em> action signals that a resource has been duplicated.</p>
+<p>The <em>Copied</em> action signals that an <a href="#Entity">Entity</a> was duplicated.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -11,5 +11,8 @@
         <em>make a replica of</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-created.html
+++ b/fragments/actions/caliper-action-created.html
@@ -1,6 +1,6 @@
 <h3>Created</h3>
-<p>The <em>Created</em> action signals that a resource has been brought into existence. Inverse of
-   <a href="#action-deleted">Deleted</a>. ... TO DO
+<p>The <em>Created</em> action signals that a <a href="#DigitalResource">DigitalResource</a> was
+    brought into existence. Inverse of <a href="#action-deleted">Deleted</a>.
 </p>
 
 <dl>
@@ -13,5 +13,8 @@
         <em>make or cause to be or to become</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-deactivated.html
+++ b/fragments/actions/caliper-action-deactivated.html
@@ -1,6 +1,6 @@
 <h3>Deactivated</h3>
-<p>The <em>Deactivated</em> action signals that some <a href="#Entity">Entity</a> has been made inactive. Inverse of
-    <a href="#action-activated">Activated</a>. ...TO DO
+<p>The <em>Deactivated</em> action signals that some <a href="#Entity">Entity</a> was made
+    inactive or stopped. Inverse of <a href="#action-activated">Activated</a>.
 </p>
 
 <dl>
@@ -9,10 +9,9 @@
     <dt>Term</dt>
     <dd>Deactivated</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00191849-v">inactivate, deactivate</a> -
-        <em>make inactive</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00191849-v">inactivate, deactivate</a>
+        - <em>make inactive</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AssignableEvent">AssignableEvent</a></dd>
-</dl>
 </dl>

--- a/fragments/actions/caliper-action-declined.html
+++ b/fragments/actions/caliper-action-declined.html
@@ -1,6 +1,6 @@
 <h3>Declined</h3>
-<p>The <em>Declined</em> action signals that some option or task was refused or declined. Inverse of
-    <a href="#action-accepted">Accepted</a>.
+<p>The <em>Declined</em> action signals that a negative reply or refusal was given with regard to
+    some <a href="#Entity">Entity</a>. Inverse of <a href="#action-accepted">Accepted</a>.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Declined</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02242120-v">decline, turn down, reject, pass up,
-        refuse</a> - <em>refuse to accept</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02242120-v">decline, turn down,
+        reject, pass up, refuse</a> - <em>refuse to accept</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SurveyInvitationEvent">SurveyInvitationEvent</a>

--- a/fragments/actions/caliper-action-deleted.html
+++ b/fragments/actions/caliper-action-deleted.html
@@ -1,6 +1,6 @@
 <h3>Deleted</h3>
-<p>The <em>Deleted</em> action signals that a resource has been removed permanently from a system. Inverse of
-    <a href="#action-created">Created</a>.
+<p>The <em>Deleted</em> action signals that a <a href="#DigitalResource">DigitalResource</a> was
+    removed permanently from a system. Inverse of <a href="#action-created">Created</a>.
 </p>
 
 <dl>
@@ -13,5 +13,8 @@
         <em>wipe out digitally or magnetically recorded information</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-described.html
+++ b/fragments/actions/caliper-action-described.html
@@ -1,5 +1,6 @@
 <h3>Described</h3>
-<p>The <em>Described</em> action signals that a description of a resource has been provided.</p>
+<p>The <em>Described</em> action signals that an explanation or elucidation of an
+    <a href="#Entity">Entity</a> was provided.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,9 +8,12 @@
     <dt>Term</dt>
     <dd>Described</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00989103-v">depict, draw, describe</a> -
-        <em>give a description of</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00989103-v">depict, draw, describe</a>
+        - <em>give a description of</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-disabledclosedcaptioning.html
+++ b/fragments/actions/caliper-action-disabledclosedcaptioning.html
@@ -1,7 +1,7 @@
 <h3>DisabledClosedCaptioning</h3>
-<p>The <em>DisabledClosedCaptioning</em> action signals that the option for visual display of plain text transcriptions
-    of audio content has been turned off or disabled. Inverse of
-    <a href="#enabledClosedCaptioning">EnabledClosedCaptioning</a>. ... TO DO
+<p>The <em>DisabledClosedCaptioning</em> action signals that the option for visual display of
+    plain text transcriptions of audio content was turned off. Inverse of
+    <a href="#enabledClosedCaptioning">EnabledClosedCaptioning</a>.
 </p>
 
 <dl>
@@ -10,8 +10,8 @@
     <dt>Term</dt>
     <dd>DisabledClosedCaptioning</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00513267-v">incapacitate, disenable, disable</a> -
-        <em>make unable to perform a certain action</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00513267-v">incapacitate, disenable,
+        disable</a> - <em>make unable to perform a certain action</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-disabledclosedcaptioning.html
+++ b/fragments/actions/caliper-action-disabledclosedcaptioning.html
@@ -13,6 +13,12 @@
     <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00513267-v">incapacitate, disenable,
         disable</a> - <em>make unable to perform a certain action</em>
     </dd>
+    <dd>Wiktionary: <a href="https://en.wiktionary.org/wiki/closed_captioning">closed captioning</a>
+        - <em>The display of text on a television or video screen, usually a transcription of the
+            audio portion of a program as it occurs (either verbatim or in edited form), most
+            frequently used by the deaf and language learners.</em> Closed <em>captions are encoded
+            invisibly, and displayed by a decoder.</em>
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-disliked.html
+++ b/fragments/actions/caliper-action-disliked.html
@@ -1,6 +1,7 @@
 <h3>Disliked</h3>
-<p>The <em>Disliked</em> action signals that a <a href="#Person">Person</a> indicated their dislike or disapproval of an
-    <a href="#Entity">Entity</a>. Inverse of <a href="#action-liked">Liked</a>. ...TO DO
+<p>The <em>Disliked</em> action signals that a <a href="#Person">Person</a> indicated disapproval of
+    or negative feeling for an <a href="#Entity">Entity</a>. Inverse of
+    <a href="#action-liked">Liked</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-downloaded.html
+++ b/fragments/actions/caliper-action-downloaded.html
@@ -1,5 +1,6 @@
 <h3>Downloaded</h3>
-<p>The <em>Downloaded</em> action signals that a copy of the resource has been transferred from a central or primary
+<p>The <em>Downloaded</em> action signals that a copy of a
+    <a href="#DigitalResource">DigitalResource</a> was transferred from a central or primary
     system to a remote or secondary system. Inverse of <a href="#action-uploaded">Uploaded</a>.
 </p>
 
@@ -10,10 +11,13 @@
     <dd>Downloaded</dd>
     <dt>Related Gloss(es)</dt>
     <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02238486-v">download</a> -
-        <em>transfer a file or program from a central computer to a smaller computer or to a computer at a remote
-            location
+        <em>transfer a file or program from a central computer to a smaller computer or to a
+            computer at a remote location
         </em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-enabledclosedcaptioning.html
+++ b/fragments/actions/caliper-action-enabledclosedcaptioning.html
@@ -13,6 +13,12 @@
     <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00513958-v">enable</a> -
         <em>render capable or able for some task</em>
     </dd>
+    <dd>Wiktionary: <a href="https://en.wiktionary.org/wiki/closed_captioning">closed captioning</a>
+        - <em>The display of text on a television or video screen, usually a transcription of the
+            audio portion of a program as it occurs (either verbatim or in edited form), most
+            frequently used by the deaf and language learners.</em> Closed <em>captions are encoded
+            invisibly, and displayed by a decoder.</em>
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-enabledclosedcaptioning.html
+++ b/fragments/actions/caliper-action-enabledclosedcaptioning.html
@@ -1,7 +1,7 @@
 <h3>EnabledClosedCaptioning</h3>
-<p>The <em>EnabledClosedCaptioning</em> action signals that the option for visual display of plain text transcriptions
-    of audio content has been turned on or enabled. Inverse of
-    <a href="#action-disabledClosedCaptioning">DisabledClosedCaptioning</a>. ...TO DO
+<p>The <em>EnabledClosedCaptioning</em> action signals that the option for visual display of
+    plain text transcriptions of audio content was turned on. Inverse of
+    <a href="#action-disabledClosedCaptioning">DisabledClosedCaptioning</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-ended.html
+++ b/fragments/actions/caliper-action-ended.html
@@ -1,6 +1,6 @@
 <h3>Ended</h3>
-<p>The <em>Ended</em> action signals that a process, task, or experience has been brought to an end. Inverse of
-    <a href="#action-started">Started</a>. ...TO DO.
+<p>The <em>Ended</em> action signals that a process associated with an <a href="#Entity">Entity</a>
+    concluded or was brought to a conclusion. Inverse of <a href="#action-started">Started</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-enteredfullscreen.html
+++ b/fragments/actions/caliper-action-enteredfullscreen.html
@@ -13,6 +13,8 @@
     <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02020375-v">move into, get into,
         go in, get in, enter, go into, come in</a> - <em>to come or go into</em>
     </dd>
+    <dd>Wiktionary: <a href="https://en.wiktionary.org/wiki/full_screen">full screen</a> - <em>Of a
+        window occupying all the available display surface of a screen</em></dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-enteredfullscreen.html
+++ b/fragments/actions/caliper-action-enteredfullscreen.html
@@ -1,6 +1,7 @@
 <h3>EnteredFullScreen</h3>
-<p>The <em>EnteredFullScreen</em> action signals that a view mode that utilizes all the available display surface of a
-    screen has been engaged. Inverse of <a href="#action-exitedFullScreen">ExitedFullScreen</a>. ...TO DO
+<p>The <em>EnteredFullScreen</em> action signals that a view mode that uses all of the available
+    display surface of a screen was engaged. Inverse of
+    <a href="#action-exitedFullScreen">ExitedFullScreen</a>.
 </p>
 
 <dl>
@@ -9,10 +10,8 @@
     <dt>Term</dt>
     <dd>EnteredFullScreen</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet:
-        <a href="http://wordnet-rdf.princeton.edu/id/02020375-v">move into, get into, go in, get in, enter, go into,
-            come in
-        </a> - <em>to come or go into</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02020375-v">move into, get into,
+        go in, get in, enter, go into, come in</a> - <em>to come or go into</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-exitedfullscreen.html
+++ b/fragments/actions/caliper-action-exitedfullscreen.html
@@ -10,9 +10,11 @@
     <dt>Term</dt>
     <dd>ExitedFullScreen</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02019450-v">exit, leave, get out, go out</a> -
-        <em>move out of or depart from</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02019450-v">exit, leave, get out, go
+        out</a> - <em>move out of or depart from</em>
     </dd>
+    <dd>Wiktionary: <a href="https://en.wiktionary.org/wiki/full_screen">full screen</a> - <em>Of a
+        window occupying all the available display surface of a screen</em></dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-exitedfullscreen.html
+++ b/fragments/actions/caliper-action-exitedfullscreen.html
@@ -1,6 +1,7 @@
 <h3>ExitedFullScreen</h3>
-<p>The <em>ExitedFullScreen</em> action signals that a view mode that utilizes all the available display surface of a
-    screen has been exited or closed. Inverse of <a href="#action-enteredFullScreen">EnteredFullScreen</a>. ...TO DO
+<p>The <em>ExitedFullScreen</em> action signals that a view mode that uses all of the available
+    display surface of a screen was left or closed. Inverse of
+    <a href="#action-enteredFullScreen">EnteredFullScreen</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-forwardedto.html
+++ b/fragments/actions/caliper-action-forwardedto.html
@@ -1,6 +1,6 @@
 <h3>ForwardedTo</h3>
-<p>The <em>ForwardedTo</em> action signals that an <a href="#Entity">Entity</a> has been sent, directed to, or shared
-    elsewhere. ...TO DO
+<p>The <em>ForwardedTo</em> action signals that an <a href="#Entity">Entity</a> was sent or
+    directed to another location.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-graded.html
+++ b/fragments/actions/caliper-action-graded.html
@@ -1,6 +1,6 @@
 <h3>Graded</h3>
-<p>The <em>Graded</em> action signals that a grade or rank has been assigned to some work or <a href=#Entity>Entity</a>.
-    ...TO DO
+<p>The <em>Graded</em> action signals that some work or <a href=#Entity>Entity</a> was given a
+    score or rank.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-hid.html
+++ b/fragments/actions/caliper-action-hid.html
@@ -1,6 +1,6 @@
 <h3>Hid</h3>
-<p>The <em>Hid</em> action signals that an <a href=#Entity>Entity</a> has been hidden or collapsed to prevent discovery.
-    Inverse of <a href="#action-showed">Showed</a>. ...TO DO
+<p>The <em>Hid</em> action signals that an <a href=#Entity>Entity</a> was collapsed or removed from
+    view to prevent discovery. Inverse of <a href="#action-showed">Showed</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-highlighted.html
+++ b/fragments/actions/caliper-action-highlighted.html
@@ -1,6 +1,6 @@
 <h3>Highlighted</h3>
-<p>The <em>Highlighted</em> action signals that some content has been marked so as to make it more prominent or visible.
-    ...TO DO
+<p>The <em>Highlighted</em> action signals that some content was marked to emphasize it or make it
+    more noticeable.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Highlighted</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00515150-v">spotlight, foreground, play up, highlight</a>
-        - <em>move into the foreground to make more visible or prominent</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00515150-v">spotlight, foreground,
+        play up, highlight</a> - <em>move into the foreground to make more visible or prominent</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AnnotationEvent">AnnotationEvent</a></dd>

--- a/fragments/actions/caliper-action-identified.html
+++ b/fragments/actions/caliper-action-identified.html
@@ -1,6 +1,6 @@
 <h3>Identified</h3>
-<p>The <em>Identified</em> action signals that the identity of an <a href=#Entity>Entity</a> has been determined or
-    established. ...TO DO
+<p>The <em>Identified</em> action signals that the essence or legitimacy of an
+    <a href=#Entity>Entity</a> was determined or established.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-jumpedto.html
+++ b/fragments/actions/caliper-action-jumpedto.html
@@ -1,6 +1,6 @@
 <h3>JumpedTo</h3>
-<p>The <em>JumpedTo</em> action signals that the active state, place, or focus was changed abruptly to another.
-    ...TO DO
+<p>The <em>JumpedTo</em> action signals that the focus was changed from one location or state of an
+    <a href="#Entity">Entity</a> to another.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-launched.html
+++ b/fragments/actions/caliper-action-launched.html
@@ -1,6 +1,6 @@
 <h3>Launched</h3>
-<p>The <em>Launched</em> action signals that a system has commenced a workflow that sends an <code>actor</code>
-    from its own domain out to an external system.
+<p>The <em>Launched</em> action signals that a system has commenced a workflow that sends an
+    <a href="#Agent">Agent</a> from its own domain out to an external system.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Launched</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01517828-v">launch, set in motion</a> -
-        <em>get going; give impetus to</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01517828-v">launch, set in motion</a>
+        - <em>get going; give impetus to</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ToolLaunchEvent">ToolLaunchEvent</a></dd>

--- a/fragments/actions/caliper-action-liked.html
+++ b/fragments/actions/caliper-action-liked.html
@@ -1,6 +1,7 @@
 <h3>Liked</h3>
-<p>The <em>Liked</em> action signals that a <a href="#Person">Person</a> indicated their liking or approval of an
-    <a href="#Entity">Entity</a>. Inverse of <a href="#action-disliked">Disliked</a>. ...TO DO
+<p>The <em>Liked</em> action signals that a <a href="#Person">Person</a> indicated approval of or
+    positive feeling for an <a href="#Entity">Entity</a>. Inverse of
+    <a href="#action-disliked">Disliked</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-linked.html
+++ b/fragments/actions/caliper-action-linked.html
@@ -1,5 +1,6 @@
 <h3>Linked</h3>
-<p>The <em>Linked</em> action signals that two or more resources were connected by way of a URI. ...TO DO</p>
+<p>The <em>Linked</em> action signals that two or more entities were connected by way of a
+    <a href="#uriDef">URI</a>.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,8 +8,8 @@
     <dt>Term</dt>
     <dd>Linked</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01357376-v">link up, link, connect, tie</a> -
-        <em>connect, fasten, or put together two or more pieces</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01357376-v">link up, link, connect,
+        tie</a> - <em>connect, fasten, or put together two or more pieces</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a></dd>

--- a/fragments/actions/caliper-action-loggedin.html
+++ b/fragments/actions/caliper-action-loggedin.html
@@ -1,7 +1,7 @@
 <h3>LoggedIn</h3>
-<p>The <em>LoggedIn</em> action signals that authenticated access to an <a href=#Entity>Entity</a>, usually a
-    <a href="#SoftwareApplication">SoftwareApplication</a>, has been granted. Inverse of
-    <a href="#action-loggedOut">LoggedOut</a>. ...TO DO
+<p>The <em>LoggedIn</em> action signals that authenticated access to a
+    <a href="#SoftwareApplication">SoftwareApplication</a> was granted. Inverse of
+    <a href="#action-loggedOut">LoggedOut</a>.
 </p>
 
 <dl>
@@ -10,8 +10,8 @@
     <dt>Term</dt>
     <dd>LoggedIn</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02253955-v">log on, log in, log-in</a> -
-        <em>enter a computer</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02253955-v">log on, log in, log-in</a>
+        - <em>enter a computer</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SessionEvent">SessionEvent</a></dd>

--- a/fragments/actions/caliper-action-loggedout.html
+++ b/fragments/actions/caliper-action-loggedout.html
@@ -1,7 +1,7 @@
 <h3>LoggedOut</h3>
-<p>The <em>LoggedOut</em> action signals that an authenticated visit to an <a href=#Entity>Entity</a>, usually a
-    <a href="#SoftwareApplication">SoftwareApplication</a>, has ended. Inverse of
-    <a href="#action-loggedIn">LoggedIn</a>. ...TO DO
+<p>The <em>LoggedOut</em> action signals that an authenticated visit to a
+    <a href="#SoftwareApplication">SoftwareApplication</a> was ended. Inverse of
+    <a href="#action-loggedIn">LoggedIn</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-markedasread.html
+++ b/fragments/actions/caliper-action-markedasread.html
@@ -1,6 +1,7 @@
 <h3>MarkedAsRead</h3>
-<p>The <em>MarkedAsRead</em> action signals that textual content has been labeled as read or consumed. Inverse of
-    <a href="#action-markedAsUnread">MarkedAsUnread</a>. ...TO DO
+<p>The <em>MarkedAsRead</em> action signals that an <a href="#Entity">Entity</a> or some textual
+    content was labeled as read or consumed. Inverse of
+    <a href="#action-markedAsUnread">MarkedAsUnread</a>.
 </p>
 
 <dl>
@@ -16,7 +17,9 @@
         <em>interpret something that is written or printed</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#MessageEvent">MessageEvent</a>,
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#MessageEvent">MessageEvent</a>,
         <a href="#ThreadEvent">ThreadEvent</a>
     </dd>
 </dl>

--- a/fragments/actions/caliper-action-markedasunread.html
+++ b/fragments/actions/caliper-action-markedasunread.html
@@ -1,6 +1,7 @@
 <h3>MarkedAsUnread</h3>
-<p>The <em>MarkedAsUnread</em> action signals that textual content has been labeled as not yet read or consumed.
-    Inverse of <a href="#action-markedAsRead">MarkedAsRead</a>. ...TO DO
+<p>The <em>MarkedAsUnread</em> action signals that an <a href="#Entity">Entity</a> or some textual
+    content was labeled as not yet read or consumed. Inverse of
+    <a href="#action-markedAsRead">MarkedAsRead</a>.
 </p>
 
 <dl>
@@ -16,7 +17,9 @@
         <em>interpret something that is written or printed</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#MessageEvent">MessageEvent</a>,
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#MessageEvent">MessageEvent</a>,
         <a href="#ThreadEvent">ThreadEvent</a>
     </dd>
 </dl>

--- a/fragments/actions/caliper-action-modified.html
+++ b/fragments/actions/caliper-action-modified.html
@@ -1,5 +1,7 @@
 <h3>Modified</h3>
-<p>The <em>Modified</em> action signals that a resource has been altered or changed.</p>
+<p>The <em>Modified</em> action signals that an <a href="#Entity">Entity</a> was altered or
+    changed.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,9 +9,12 @@
     <dt>Term</dt>
     <dd>Modified</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00126072-v">modify, alter, change</a> -
-        <em>cause to change; make different; cause a transformation</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00126072-v">modify, alter, change</a>
+        - <em>cause to change; make different; cause a transformation</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-muted.html
+++ b/fragments/actions/caliper-action-muted.html
@@ -1,6 +1,6 @@
 <h3>Muted</h3>
-<p>The <em>Muted</em> action signals that the sound associated with an <a href=#Entity>Entity</a> has been cut off or
-    silenced. Inverse of <a href="#action-unmuted">Unmuted</a>. ...TO DO
+<p>The <em>Muted</em> action signals that the sound associated with an <a href=#Entity>Entity</a>
+    was cut off or silenced. Inverse of <a href="#action-unmuted">Unmuted</a>.
 </p>
 
 <dl>
@@ -10,8 +10,8 @@
     <dd>Muted</dd>
     <dt>Related Gloss(es)</dt>
     <dd>WordNet:
-        <a href="http://wordnet-rdf.princeton.edu/id/02195757-v">dampen, tone down, damp, dull, muffle, mute</a>
-        - <em>deaden (a sound or noise), especially by wrapping</em>
+        <a href="http://wordnet-rdf.princeton.edu/id/02195757-v">dampen, tone down, damp, dull,
+            muffle, mute</a> - <em>deaden (a sound or noise), especially by wrapping</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-navigatedto.html
+++ b/fragments/actions/caliper-action-navigatedto.html
@@ -1,6 +1,6 @@
 <h3>NavigatedTo</h3>
-<p>The <em>NavigatedTo</em> action signals that some <a href="#Entity">Entity</a> directed a movement from one location
-    to another. ...TO DO
+<p>The <em>NavigatedTo</em> action signals that an <a href="#Agent">Agent</a> directed a movement
+    from one location to another.
 </p>
 
 <dl>
@@ -13,5 +13,5 @@
         <em>direct carefully and safely</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#NavigationEvent">NavigationEvent</a>
+    <dd><a href="#Event">Event</a>, <a href="#NavigationEvent">NavigationEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-openedpopout.html
+++ b/fragments/actions/caliper-action-openedpopout.html
@@ -1,6 +1,6 @@
 <h3>OpenedPopout</h3>
-<p>The <em>OpenedPopout</em> action signals that a video popout has been opened. Inverse of
-    <a href="#action-closedPopout">ClosedPopout</a>. ...TO DO
+<p>The <em>OpenedPopout</em> action signals that a video popout was opened. Inverse of
+    <a href="#action-closedPopout">ClosedPopout</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-optedin.html
+++ b/fragments/actions/caliper-action-optedin.html
@@ -1,7 +1,6 @@
 <h3>OptedIn</h3>
-<p>The <em>OptedIn</em> action signals that a <a href="#Person">Person</a> has agreed to participate in an optional
-    activity or task, such as a <a href="#Survey">Survey</a>. Inverse of <a href="#action-opted-out">OptedOut</a>.
-    ...TO DO
+<p>The <em>OptedIn</em> action signals that a <a href="#Person">Person</a> agreed to participate in
+    an activity or complete a task. Inverse of <a href="#action-opted-out">OptedOut</a>.
 </p>
 
 <dl>
@@ -10,9 +9,10 @@
     <dt>Term</dt>
     <dd>OptedIn</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>Wiktionary: <a href="https://en.wiktionary.org/w/index.php?title=opt_in&oldid=50819928">opt in</a> -
+    <dd>Wiktionary:
+        <a href="https://en.wiktionary.org/w/index.php?title=opt_in&oldid=50819928">opt in</a> -
         <em>To choose to participate in something</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#SurveyEvent">SurveyEvent</a>
+    <dd><a href="#Event">Event</a>, <a href="#SurveyEvent">SurveyEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-optedin.html
+++ b/fragments/actions/caliper-action-optedin.html
@@ -10,8 +10,8 @@
     <dd>OptedIn</dd>
     <dt>Related Gloss(es)</dt>
     <dd>Wiktionary:
-        <a href="https://en.wiktionary.org/w/index.php?title=opt_in&oldid=50819928">opt in</a> -
-        <em>To choose to participate in something</em>
+        <a href="https://en.wiktionary.org/wiki/opt_in">opt in</a> - <em>To choose to participate in
+            something</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SurveyEvent">SurveyEvent</a></dd>

--- a/fragments/actions/caliper-action-optedout.html
+++ b/fragments/actions/caliper-action-optedout.html
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>OptedOut</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>Wiktionary: <a href="https://en.wiktionary.org/w/index.php?title=opt_out&oldid=50769215">opt
-        out</a> - <em>To choose not to participate in something</em>
+    <dd>Wiktionary: <a href="https://en.wiktionary.org/wiki/opt_out">opt out</a> - <em>To choose not
+        to participate in something</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SurveyEvent">SurveyEvent</a></dd>

--- a/fragments/actions/caliper-action-optedout.html
+++ b/fragments/actions/caliper-action-optedout.html
@@ -1,7 +1,6 @@
 <h3>OptedOut</h3>
-<p>The <em>OptedOut</em> action signals that a <a href="#Person">Person</a> has declined to participate in an optional
-    activity or task, such as a <a href="#Survey">Survey</a>. Inverse of <a href="#action-optedIn">OptedIn</a>.
-    ...TO DO
+<p>The <em>OptedOut</em> action signals that a <a href="#Person">Person</a> declined to participate
+    in an activity or complete a task. Inverse of <a href="#action-optedIn">OptedIn</a>.
 </p>
 
 <dl>
@@ -10,9 +9,9 @@
     <dt>Term</dt>
     <dd>OptedOut</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>Wiktionary: <a href="https://en.wiktionary.org/w/index.php?title=opt_out&oldid=50769215">opt out</a> -
-        <em>To choose not to participate in something</em>
+    <dd>Wiktionary: <a href="https://en.wiktionary.org/w/index.php?title=opt_out&oldid=50769215">opt
+        out</a> - <em>To choose not to participate in something</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#SurveyEvent">SurveyEvent</a>
+    <dd><a href="#Event">Event</a>, <a href="#SurveyEvent">SurveyEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-paused.html
+++ b/fragments/actions/caliper-action-paused.html
@@ -1,6 +1,6 @@
 <h3>Paused</h3>
-<p>The <em>Paused</em> action signals that some task or process has been temporarily stopped. Inverse of
-    <a href="#action-resumed">Resumed</a>. ...TO DO
+<p>The <em>Paused</em> action signals that some task or process was temporarily stopped. Inverse of
+    <a href="#action-resumed">Resumed</a>.
 </p>
 
 <dl>
@@ -13,7 +13,9 @@
         <em>cease an action temporarily</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#AssessmentEvent">AssessmentEvent</a>,
         <a href="#MediaEvent">MediaEvent</a>
     </dd>
 </dl>

--- a/fragments/actions/caliper-action-posted.html
+++ b/fragments/actions/caliper-action-posted.html
@@ -1,6 +1,6 @@
 <h3>Posted</h3>
-<p>The <em>Posted</em> action signals that some <a href=#Entity>Entity</a> has been published in a shared space.
-    ...TO DO
+<p>The <em>Posted</em> action signals that some <a href=#Entity>Entity</a> was made accessible in a
+    shared location.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-printed.html
+++ b/fragments/actions/caliper-action-printed.html
@@ -1,6 +1,6 @@
 <h3>Printed</h3>
-<p>The <em>Printed</em> action signals that a mechanical process has been invoked in order to produce a printed
-    representation of a resource.
+<p>The <em>Printed</em> action signals that a mechanical process was invoked in order to produce
+    a physical representation of an <a href="#Entity">Entity</a>.
 </p>
 
 <dl>
@@ -13,5 +13,8 @@
         <em>reproduce by printing</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-published.html
+++ b/fragments/actions/caliper-action-published.html
@@ -1,5 +1,7 @@
 <h3>Published</h3>
-<p>The <em>Published</em> action signals that a resource is now available for public consumption.</p>
+<p>The <em>Published</em> action signals that an <a href="#Entity">Entity</a> was made available for
+    public consumption.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,10 +9,12 @@
     <dt>Term</dt>
     <dd>Published</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet:
-        <a href="http://wordnet-rdf.princeton.edu/id/00969657-v">release, issue, publish, put out, bring out</a>
-        - <em>prepare and issue for public distribution or sale</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00969657-v">release, issue, publish,
+        put out, bring out</a> - <em>prepare and issue for public distribution or sale</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-questioned.html
+++ b/fragments/actions/caliper-action-questioned.html
@@ -1,5 +1,5 @@
 <h3>Questioned</h3>
-<p>The <em>Questioned</em> action signals that a question has been posed. ...TO DO</p>
+<p>The <em>Questioned</em> action signals that some request for information was made.</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-ranked.html
+++ b/fragments/actions/caliper-action-ranked.html
@@ -1,6 +1,6 @@
 <h3>Ranked</h3>
-<p>The <em>Ranked</em> action signals that quantitative feedback in the form of a <a href="#Rating">Rating</a> has been
-    provided.
+<p>The <em>Ranked</em> action signals that quantitative feedback in the form of a
+    <a href="#Rating">Rating</a> was provided.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Ranked</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00659723-v">range, rank, order, rate, place, grade</a> -
-        <em>assign a rank or rating to</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00659723-v">range, rank, order, rate,
+        place, grade</a> - <em>assign a rank or rating to</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#FeedbackEvent">FeedbackEvent</a></dd>

--- a/fragments/actions/caliper-action-recommended.html
+++ b/fragments/actions/caliper-action-recommended.html
@@ -1,5 +1,6 @@
 <h3>Recommended</h3>
-<p>The <em>Recommended</em> action signals that some <a href=#Entity>Entity</a> or option is favored. ...TO DO</p>
+<p>The <em>Recommended</em> action signals that some <a href=#Entity>Entity</a> was given a
+    favorable label or review.</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-removed.html
+++ b/fragments/actions/caliper-action-removed.html
@@ -1,6 +1,6 @@
 <h3>Removed</h3>
-<p>The <em>Removed</em> action signals the taking away or deletion of some <a href=#Entity>Entity</a>. Inverse of
-    <a href="#action-added">Added</a>. ...TO DO
+<p>The <em>Removed</em> action signals the taking away or disposal of some
+    <a href=#Entity>Entity</a>. Inverse of <a href="#action-added">Added</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-reset.html
+++ b/fragments/actions/caliper-action-reset.html
@@ -1,6 +1,6 @@
 <h3>Reset</h3>
-<p>The <em>Reset</em> action signals that an <a href=#Entity>Entity</a> has been refreshed or returned to its original
-    state. ...TO DO
+<p>The <em>Reset</em> action signals that an <a href=#Entity>Entity</a> was refreshed or returned to
+    some initial state.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-restarted.html
+++ b/fragments/actions/caliper-action-restarted.html
@@ -1,6 +1,6 @@
 <h3>Restarted</h3>
-<p>The <em>Restarted</em> action signals that a process or task has begun again from the beginning, following a
-    previous run or attempt. ...TO DO
+<p>The <em>Restarted</em> action signals that a process or task was begun again from some initial
+    location, following a previous run or attempt.
 </p>
 
 <dl>
@@ -9,11 +9,13 @@
     <dt>Term</dt>
     <dd>Restarted</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00350758-v">resume, restart, re-start</a> -
-        <em>take up or begin anew</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00350758-v">resume, restart,
+        re-start</a> - <em>take up or begin anew</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#AssessmentEvent">AssessmentEvent</a>,
         <a href="#MediaEvent">MediaEvent</a>
     </dd>
 </dl>

--- a/fragments/actions/caliper-action-restored.html
+++ b/fragments/actions/caliper-action-restored.html
@@ -1,6 +1,6 @@
 <h3>Restored</h3>
-<p>The <em>Restored</em> action signals that an archived resource has been retrieved from long-term storage. Inverse of
-    <a href="#action-archived">Archived</a>.
+<p>The <em>Restored</em> action signals that an archived <a href="#Entity">Entity</a> was retrieved
+    from long-term storage. Inverse of <a href="#action-archived">Archived</a>.
 </p>
 
 <dl>
@@ -13,5 +13,8 @@
         <em>return to its original or usable and functioning condition</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-resumed.html
+++ b/fragments/actions/caliper-action-resumed.html
@@ -1,6 +1,6 @@
 <h3>Resumed</h3>
-<p>The <em>Resumed</em> action signals that a process or task was started midway through after it was previously paused
-    at that place. Inverse of <a href="#action-paused">Paused</a>. ...TO DO
+<p>The <em>Resumed</em> action signals that a process or task was started midway through after it
+    was previously stopped at that place. Inverse of <a href="#action-paused">Paused</a>.
 </p>
 
 <dl>
@@ -9,11 +9,13 @@
     <dt>Term</dt>
     <dd>Resumed</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00350758-v">resume, restart, re-start</a> -
-        <em>take up or begin anew</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00350758-v">resume, restart,
+        re-start</a> - <em>take up or begin anew</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#AssessmentEvent">AssessmentEvent</a>,
         <a href="#MediaEvent">MediaEvent</a>
     </dd>
 </dl>

--- a/fragments/actions/caliper-action-retrieved.html
+++ b/fragments/actions/caliper-action-retrieved.html
@@ -1,5 +1,7 @@
 <h3>Retrieved</h3>
-<p>The <em>Retrieved</em> action signals that a resource has been accessed or obtained.</p>
+<p>The <em>Retrieved</em> action signals that an <a href="#Entity">Entity</a> was accessed or
+    obtained from storage.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -11,5 +13,8 @@
         <em>obtain or retrieve from a storage device; as of information on a computer</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-returned.html
+++ b/fragments/actions/caliper-action-returned.html
@@ -1,6 +1,7 @@
 <h3>Returned</h3>
-<p>The <em>Returned</em> action signals that the workflow that started with the <em>Launched</em> action gets completed
-    when the external tool redirects the user back to the launching system.
+<p>The <em>Returned</em> action signals that a workflow that started with the
+    <a href="#action-launched">Launched</a> action was completed, with the
+    <a href="#Agent">Agent</a> being directed back to an original location or system.
 </p>
 
 <dl>
@@ -10,7 +11,7 @@
     <dd>Returned</dd>
     <dt>Related Gloss(es)</dt>
     <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02008888-v">return</a> -
-        <em>go or come back to place, condition, or activity where one has been before</em>
+        <em>go or come back to place, condition, or activity where one was before</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ToolLaunchEvent">ToolLaunchEvent</a></dd>

--- a/fragments/actions/caliper-action-reviewed.html
+++ b/fragments/actions/caliper-action-reviewed.html
@@ -1,6 +1,6 @@
 <h3>Reviewed</h3>
-<p>The <em>Reviewed</em> action signals that an <a href=#Entity>Entity</a> has been looked over or appraised for its
-    quality and completeness. ...TO DO
+<p>The <em>Reviewed</em> action signals that an <a href=#Entity>Entity</a> was looked over or
+    appraised for its quality and completeness.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-rewound.html
+++ b/fragments/actions/caliper-action-rewound.html
@@ -1,6 +1,6 @@
 <h3>Rewound</h3>
-<p>The <em>Rewound</em> action signals that a process was moved back from a current place or state to a previous one.
-    ...TO DO
+<p>The <em>Rewound</em> action signals that a process was moved back from a current place or state
+    to a previous one.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-saved.html
+++ b/fragments/actions/caliper-action-saved.html
@@ -1,5 +1,7 @@
 <h3>Saved</h3>
-<p>The <em>Saved</em> action signals that the current state of a resource has been stored for future use.</p>
+<p>The <em>Saved</em> action signals that the current state of an <a href="#Entity">Entity</a> was
+    stored for future use.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -11,5 +13,8 @@
         <em>record data on a computer</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-searched.html
+++ b/fragments/actions/caliper-action-searched.html
@@ -1,6 +1,6 @@
 <h3>Searched</h3>
-<p>The <em>Searched</em> action signals that an <code>actor</code>, typically a learner, has queried a resource for
-    information.
+<p>The <em>Searched</em> action signals that a <a href="#Person">Person</a> has queried an
+    <a href="#Entity">Entity</a> to find information or other entities.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Searched</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00649877-v">search, explore, research</a> -
-        <em>inquire into</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00649877-v">search, explore,
+        research</a> - <em>inquire into</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SearchEvent">SearchEvent</a></dd>

--- a/fragments/actions/caliper-action-sent.html
+++ b/fragments/actions/caliper-action-sent.html
@@ -1,6 +1,6 @@
 <h3>Sent</h3>
-<p>The <em>Sent</em> action signals that some <a href="#Entity">Entity</a> has been transmitted or transferred.
-    ...TO DO
+<p>The <em>Sent</em> action signals that some <a href="#Entity">Entity</a> was transmitted or
+    transferred.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Sent</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01064577-v">send, get off, send off</a> -
-        <em>transfer</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01064577-v">send, get off, send
+        off</a> - <em>transfer</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SurveyInvitationEvent">SurveyInvitationEvent</a>

--- a/fragments/actions/caliper-action-shared.html
+++ b/fragments/actions/caliper-action-shared.html
@@ -1,6 +1,6 @@
 <h3>Shared</h3>
-<p>The <em>Shared</em> action signals that a reference to an <a href=#Entity>Entity</a> was communicated in order to
-    share with others an experience, information, or knowledge. ...TO DO
+<p>The <em>Shared</em> action signals that a reference to an <a href=#Entity>Entity</a> was
+    communicated so that others might experience or learn from the <a href=#Entity>Entity</a>.
 </p>
 
 <dl>
@@ -9,7 +9,8 @@
     <dt>Term</dt>
     <dd>Shared</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01065952-v">share</a> - <em>communicate</em></dd>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01065952-v">share</a> -
+        <em>communicate</em></dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AnnotationEvent">AnnotationEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-showed.html
+++ b/fragments/actions/caliper-action-showed.html
@@ -1,6 +1,6 @@
 <h3>Showed</h3>
-<p>The <em>Showed</em> action signals that an <a href=#Entity>Entity</a> has been revealed or made visible to enable
-    discovery. Inverse of <a href="#action-hid">Hid</a>. ...TO DO
+<p>The <em>Showed</em> action signals that an <a href=#Entity>Entity</a> was revealed or made
+    accessible to enable discovery. Inverse of <a href="#action-hid">Hid</a>.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-skipped.html
+++ b/fragments/actions/caliper-action-skipped.html
@@ -1,5 +1,7 @@
 <h3>Skipped</h3>
-<p>The <em>Skipped</em> action signals that some <a href="#Entity">Entity</a> has been bypassed. ...TO DO</p>
+<p>The <em>Skipped</em> action signals that some <a href="#Entity">Entity</a> was passed over
+    without being fully examined or completed.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,10 +9,13 @@
     <dt>Term</dt>
     <dd>Skipped</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00618188-v">jump, skip, pass over, skip over</a> -
-        <em>bypass</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00618188-v">jump, skip, pass over,
+        skip over</a> - <em>bypass</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#AssessmentItemEvent">AssessmentItemEvent</a>,
-        <a href="#QuestionnaireItemEvent">QuestionnaireItemEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#AssessmentItemEvent">AssessmentItemEvent</a>,
+        <a href="#QuestionnaireItemEvent">QuestionnaireItemEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-started.html
+++ b/fragments/actions/caliper-action-started.html
@@ -1,5 +1,5 @@
 <h3>Started</h3>
-<p>The <em>Started</em> action signals that some process or task has commenced. ...TO DO</p>
+<p>The <em>Started</em> action signals that some process or task was begun or initiated.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,12 +7,15 @@
     <dt>Term</dt>
     <dd>Started</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00349400-v">commence, start, lead off, begin</a> -
-        <em>set in motion, cause to start</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00349400-v">commence, start, lead off,
+        begin</a> - <em>set in motion, cause to start</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
-        <a href="#AssessmentItemEvent">AssessmentItemEvent</a>, <a href="#QuestionnaireEvent">QuestionnaireEvent</a>,
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#AssessmentEvent">AssessmentEvent</a>,
+        <a href="#AssessmentItemEvent">AssessmentItemEvent</a>,
+        <a href="#QuestionnaireEvent">QuestionnaireEvent</a>,
         <a href="#QuestionnaireItemEvent">QuestionnaireItemEvent</a>
     </dd>
 </dl>

--- a/fragments/actions/caliper-action-submitted.html
+++ b/fragments/actions/caliper-action-submitted.html
@@ -1,6 +1,6 @@
 <h3>Submitted</h3>
-<p>The <em>Submitted</em> action signals that some <a href="#Entity">Entity</a> has been formally turned in.
-    ...TO DO
+<p>The <em>Submitted</em> action signals that some <a href="#Entity">Entity</a> was formally turned
+    in for review or analysis.
 </p>
 
 <dl>
@@ -13,7 +13,9 @@
         <em>hand over formally</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#AssessmentEvent">AssessmentEvent</a>,
         <a href="#QuestionnaireEvent">QuestionnaireEvent</a>
     </dd>
 </dl>

--- a/fragments/actions/caliper-action-subscribed.html
+++ b/fragments/actions/caliper-action-subscribed.html
@@ -1,6 +1,6 @@
 <h3>Subscribed</h3>
-<p>The <em>Subscribed</em> action signals that a request was made for the regular delivery of information. Inverse
-    of <a href="#action-unsubscribed">Unsubscribed</a>. ...TO DO
+<p>The <em>Subscribed</em> action signals that a request was made for the regular delivery of
+    information. Inverse of <a href="#action-unsubscribed">Unsubscribed</a>.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Subscribed</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02214527-v">subscribe to, subscribe, take</a> -
-        <em>receive or obtain regularly</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02214527-v">subscribe to, subscribe,
+        take</a> - <em>receive or obtain regularly</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ForumEvent">ForumEvent</a></dd>

--- a/fragments/actions/caliper-action-tagged.html
+++ b/fragments/actions/caliper-action-tagged.html
@@ -1,5 +1,7 @@
 <h3>Tagged</h3>
-<p>The <em>Tagged</em> action signals that some kind of content was given a tag or label. ...TO DO</p>
+<p>The <em>Tagged</em> action signals that an <a href="#Entity">Entity</a> or content was given a
+    label to assist with future discovery and identification.
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-timedout.html
+++ b/fragments/actions/caliper-action-timedout.html
@@ -9,7 +9,9 @@
     <dt>Term</dt>
     <dd>TimedOut</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>...TO DO</dd>
+    <dd>Wiktionary: <a href="https://en.wiktionary.org/wiki/time_out">time out</a> - <em>of a task,
+        to be terminated because it was not completed before a time limit</em>
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SessionEvent">SessionEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-timedout.html
+++ b/fragments/actions/caliper-action-timedout.html
@@ -1,6 +1,6 @@
 <h3>TimedOut</h3>
-<p>The <em>TimedOut</em> action signals that a user session was cancelled after a predetermined time interval passed
-    without activity. ...TO DO
+<p>The <em>TimedOut</em> action signals that a user session was cancelled after a predetermined time
+    interval passed without activity.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-unmuted.html
+++ b/fragments/actions/caliper-action-unmuted.html
@@ -1,6 +1,6 @@
 <h3>Unmuted</h3>
-<p>The <em>Unmuted</em> action signals that the sound associated with an <a href=#Entity>Entity</a> has been enabled or
-    made audible. Inverse of <a href="#action-muted">Muted</a>. ...TO DO
+<p>The <em>Unmuted</em> action signals that the sound associated with an <a href=#Entity>Entity</a>
+    was enabled or made audible. Inverse of <a href="#action-muted">Muted</a>.
 </p>
 
 <dl>
@@ -9,9 +9,8 @@
     <dt>Term</dt>
     <dd>Unmuted</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet:
-        <a href="http://wordnet-rdf.princeton.edu/id/02195757-v">dampen, tone down, damp, dull, muffle, mute</a>
-        - <em>deaden (a sound or noise), especially by wrapping</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02195757-v">dampen, tone down, damp,
+        dull, muffle, mute</a> - <em>deaden (a sound or noise), especially by wrapping</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-unpublished.html
+++ b/fragments/actions/caliper-action-unpublished.html
@@ -1,6 +1,7 @@
 <h3>Unpublished</h3>
-<p>The <em>Unpublished</em> action signals that a published resource has been rendered unavailable for public
-    consumption. Inverse of <a href="#action-published">Published</a>.
+<p>The <em>Unpublished</em> action signals that a published <a href="#Entity">Entity</a> was
+    rendered unavailable for public consumption. Inverse of
+    <a href="#action-published">Published</a>.
 </p>
 
 <dl>
@@ -9,10 +10,12 @@
     <dt>Term</dt>
     <dd>Unpublished</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet:
-        <a href="http://wordnet-rdf.princeton.edu/id/00969657-v">release, issue, publish, put out, bring out</a>
-        - <em>prepare and issue for public distribution or sale</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/00969657-v">release, issue, publish,
+        put out, bring out</a> - <em>prepare and issue for public distribution or sale</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-unsubscribed.html
+++ b/fragments/actions/caliper-action-unsubscribed.html
@@ -1,6 +1,6 @@
 <h3>Unsubscribed</h3>
-<p>The <em>Unsubscribed</em> action signals that a request was made for the regular delivery of information to be
-    stopped or ceased. Inverse of <a href="#action-subscribed">Subscribed</a>. ...TO DO
+<p>The <em>Unsubscribed</em> action signals that a request was made for the regular delivery of
+    information to be stopped or ceased. Inverse of <a href="#action-subscribed">Subscribed</a>.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Unsubscribed</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02214527-v">subscribe to, subscribe, take</a> -
-        <em>receive or obtain regularly</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02214527-v">subscribe to, subscribe,
+        take</a> - <em>receive or obtain regularly</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ForumEvent">ForumEvent</a></dd>

--- a/fragments/actions/caliper-action-uploaded.html
+++ b/fragments/actions/caliper-action-uploaded.html
@@ -1,6 +1,7 @@
 <h3>Uploaded</h3>
-<p>The <em>Uploaded</em> action signals that a copy of the resource has been transferred from a remote or secondary
-    system to a central or primary system. Inverse of <a href="#action-downloaded">Downloaded</a>.
+<p>The <em>Uploaded</em> action signals that a copy of a
+    <a href="#DigitalResource">DigitalResource</a> was transferred from a remote or secondary system
+    to a central or primary system. Inverse of <a href="#action-downloaded">Downloaded</a>.
 </p>
 
 <dl>
@@ -9,11 +10,13 @@
     <dt>Term</dt>
     <dd>Uploaded</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02238680-v">upload</a> -
-        <em>transfer a file or program to a central computer from a smaller computer or a computer at a remote
-            location
-        </em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02238680-v">upload</a> - <em>transfer
+        a file or program to a central computer from a smaller computer or a computer at a remote
+        location</em>
     </dd>
     <dt>Supported by</dt>
-    <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
+    <dd>
+        <a href="#Event">Event</a>,
+        <a href="#ResourceManagementEvent">ResourceManagementEvent</a>
+    </dd>
 </dl>

--- a/fragments/actions/caliper-action-used.html
+++ b/fragments/actions/caliper-action-used.html
@@ -1,7 +1,6 @@
 <h3>Used</h3>
-<p>The <em>Used</em> action signals that a <code>actor</code> has utilized a
-    <a href="#SoftwareApplication">SoftwareApplication</a> in a manner that the application determines to be its
-    intended use for learning.
+<p>The <em>Used</em> action signals that an <a href="#Agent">Agent</a> utilized or employed an
+    <a href="#Entity">Entity</a> for some purpose.
 </p>
 
 <dl>
@@ -10,8 +9,9 @@
     <dt>Term</dt>
     <dd>Used</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01161188-v">utilise, use, employ, utilize, apply</a> -
-        <em>put into service; make work or employ for a particular purpose or for its inherent or natural purpose</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/01161188-v">utilise, use, employ,
+        utilize, apply</a> - <em>put into service; make work or employ for a particular purpose or
+        for its inherent or natural purpose</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ToolUseEvent">ToolUseEvent</a></dd>

--- a/fragments/actions/caliper-action-viewed.html
+++ b/fragments/actions/caliper-action-viewed.html
@@ -1,6 +1,6 @@
 <h3>Viewed</h3>
-<p>The <em>Viewed</em> action signals that a <a href="#Person">Person</a> carefully viewed or studied a particular
-    <a href="#Entity">Entity</a> ...TO DO
+<p>The <em>Viewed</em> action signals that a <a href="#Person">Person</a> examined or studied a
+    particular <a href="#Entity">Entity</a>.
 </p>
 
 <dl>
@@ -9,8 +9,8 @@
     <dt>Term</dt>
     <dd>Viewed</dd>
     <dt>Related Gloss(es)</dt>
-    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02134765-v">consider, look at, view</a> -
-        <em>look at carefully; study mentally</em>
+    <dd>WordNet: <a href="http://wordnet-rdf.princeton.edu/id/02134765-v">consider, look at,
+        view</a> - <em>look at carefully; study mentally</em>
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ViewEvent">ViewEvent</a></dd>

--- a/fragments/entities/caliper-entity-ltilink.html
+++ b/fragments/entities/caliper-entity-ltilink.html
@@ -1,7 +1,7 @@
 <h3>LtiLink</h3>
-<p>The <code>LtiLink</code> entity represents a <a href="DigitalResource">DigitalResource</a> that must be
+<p>The <code>LtiLink</code> entity represents a <a href="#DigitalResource">DigitalResource</a> that must be
     retrieved from an external tool application via an LTI request message. It is, effectively, a
-    <a href="DigitalResource">DigitalResource</a> that requiries use of LTI for access.
+    <a href="#DigitalResource">DigitalResource</a> that requires use of LTI for access.
 </p>
 
 <dl>

--- a/fragments/events/caliper-event-tooluse.html
+++ b/fragments/events/caliper-event-tooluse.html
@@ -81,7 +81,7 @@
             </br>
             Note that if the sender of the event wants to send aggregate measure information
             as part of this <a href="#ToolUseEvent">ToolUseEvent</a> it should, by best practice, send a single
-            <a href="AggregateMeasureCollection">AggregateMeasureCollection</a> as
+            <a href="#AggregateMeasureCollection">AggregateMeasureCollection</a> as
             the <code>generated</code> value.
         </td>
         <td>Optional</td>

--- a/fragments/profiles/caliper-profile-resourcemanagement.html
+++ b/fragments/profiles/caliper-profile-resourcemanagement.html
@@ -27,7 +27,7 @@
 </ul>
 
 <p>The Resource Management Profile defines a <a href="#ResourceManagementEvent">ResourceManagementEvent</a> for
-    describing the creation, management, and disposition of <a href="DigitalResource">DigitalResource</a> entities.
+    describing the creation, management, and disposition of <a href="#DigitalResource">DigitalResource</a> entities.
     Fourteen actions are described:
 </p>
 

--- a/fragments/roles/lis-role-instructor.html
+++ b/fragments/roles/lis-role-instructor.html
@@ -5,6 +5,7 @@
     <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor</dd>
     <dt>Term</dt>
     <dd>Instructor</dd>
+    <dt>Subrole(s)</dt>
     <dd>
         <section id="subrole-instructor-externalinstructor" class="notoc">
             <h4>Instructor#ExternalInstructor</h4>

--- a/profiles/resource_management/caliper-profile-resource_management-v1p1.html
+++ b/profiles/resource_management/caliper-profile-resource_management-v1p1.html
@@ -45,7 +45,7 @@
         <img height="100%" width="100%" src="./assets/caliper-profile_resource_management.png"
              alt="Resource Management Profile"/>
 
-        <p>The Caliper Resource Management Profile models a <a href="Person">Person</a>
+        <p>The Caliper Resource Management Profile models a <a href="#Person">Person</a>
             managing a <a href="#DigitalResource">DigitalResource</a>. The profile provides a
             <a href="#ResourceManagementEvent">ResourceManagementEvent</a> with several actions
             describing how the resource is being managed:


### PR DESCRIPTION
This PR includes significant changes to the text of the action section of caliper-spec-v1p2.html and the associated action fragments, as well as some miscellaneous fixes. Changes can be grouped into the following general areas:

1) Edits and updates to the description of each action in its associated fragment HTML document. Particular effort was made to keep descriptions general when possible so the action could be construed to apply to both Event subtypes and the general Event. Conjugations of 'to be' verbs were changed whenever possible from "has been" to "was". All instances of the term resource or resources were changed to a reference to Entity, one of its subtypes, or 'entities'. The terms DigitalResource, Agent, Person, and a few other Entity subtypes were referenced in definitions in cases where the action term seemed to rule out a more general term.

2) Definitions from [Wiktionary](https://en.wiktionary.org/wiki/Wiktionary:Main_Page) were added under Related Glosses(es) in HTML action fragments when deemed appropriate. The introductory text to the Actions section of the appendix was also updated to mention Wiktionary and the possibility of multiple glosses for a single action term.

3) Miscellaneous changes were also made to other specification-related HTML documents in the repository, typically because a typographical error, broken link, or missing structural element was discovered.