### PR TITLE
Typo: remove <h3> tag.

### DIFF
--- a/fragments/identifiers/caliper-identifier-other.html
+++ b/fragments/identifiers/caliper-identifier-other.html
@@ -3,7 +3,6 @@
 <p>Set the <code>SystemIdentifier.identifierType</code> string value to <em>Other</em> if the
     <a href="#SystemIdentifier">SystemIdentifier</a> has no matching enumerated type.</p>
 
-<h3>Other</h3>
 <dl>
     <dt>IRI</dt>
     <dd>http://purl.imsglobal.org/vocab/systemIdentifiers/Other</dd>


### PR DESCRIPTION
This PR removes an extraneous `<h3>Other</h3> tag.