### PR TITLE
Add missing type property.

### DIFF
--- a/fragments/identifiers/caliper-identifier-systemidentifier.html
+++ b/fragments/identifiers/caliper-identifier-systemidentifier.html
@@ -29,9 +29,9 @@
     </thead>
     <tbody>
     <tr>
-        <td>identifier</td>
-        <td>string</td>
-        <td>Opaque string representing the system identifier value.</td>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>SystemIdentifier</em>.</td>
         <td>Required</td>
     </tr>
     <tr>
@@ -39,6 +39,12 @@
         <td>string</td>
         <td>The string value MUST be set to the <a href="#systemidentifiertype">System Identifier Type</a> constants
             that describes the <code>identifier</code>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>identifier</td>
+        <td>string</td>
+        <td>Opaque string representing the system identifier value.</td>
         <td>Required</td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR adds a missing table row that describes the `type` property for the `SystemIdentifier`.