### PR TITLE
Update ontology with missing 1.2 terms

### DIFF
--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -13,15 +13,134 @@
 }, {
   "@id" : "_:genid100",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid104"
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Bookmarked"
     }, {
-      "@id" : "_:genid102"
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Highlighted"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Shared"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Tagged"
     } ]
   } ]
 }, {
-  "@id" : "_:genid102",
+  "@id" : "_:genid106",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid107",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid111"
+    }, {
+      "@id" : "_:genid109"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid109",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid11",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MultiselectQuestion"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid111",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid112",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid116"
+    }, {
+      "@id" : "_:genid114"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid114",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid116",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid117",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/generated"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Annotation"
+  } ]
+}, {
+  "@id" : "_:genid118",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/target"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Frame"
+  } ]
+}, {
+  "@id" : "_:genid119",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid122",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid126"
+    }, {
+      "@id" : "_:genid124"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid124",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AssessmentItem"
@@ -30,7 +149,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/items"
   } ]
 }, {
-  "@id" : "_:genid104",
+  "@id" : "_:genid126",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/items"
@@ -39,26 +158,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
   } ]
 }, {
-  "@id" : "_:genid105",
+  "@id" : "_:genid127",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid116"
+      "@id" : "_:genid138"
     }, {
-      "@id" : "_:genid107"
+      "@id" : "_:genid129"
     } ]
   } ]
 }, {
-  "@id" : "_:genid107",
+  "@id" : "_:genid129",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid108"
+    "@id" : "_:genid130"
   } ]
 }, {
-  "@id" : "_:genid108",
+  "@id" : "_:genid130",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -76,17 +195,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid11",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid116",
+  "@id" : "_:genid138",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -95,17 +204,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid117",
+  "@id" : "_:genid139",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid121"
+      "@id" : "_:genid143"
     }, {
-      "@id" : "_:genid119"
+      "@id" : "_:genid141"
     } ]
   } ]
 }, {
-  "@id" : "_:genid119",
+  "@id" : "_:genid141",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -114,7 +223,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid121",
+  "@id" : "_:genid143",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -123,17 +232,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid122",
+  "@id" : "_:genid144",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid126"
+      "@id" : "_:genid148"
     }, {
-      "@id" : "_:genid124"
+      "@id" : "_:genid146"
     } ]
   } ]
 }, {
-  "@id" : "_:genid124",
+  "@id" : "_:genid146",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Assessment"
@@ -142,7 +251,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid126",
+  "@id" : "_:genid148",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -151,7 +260,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
   } ]
 }, {
-  "@id" : "_:genid127",
+  "@id" : "_:genid149",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -160,17 +269,29 @@
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
   } ]
 }, {
-  "@id" : "_:genid128",
+  "@id" : "_:genid15",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid132"
+      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
     }, {
-      "@id" : "_:genid130"
+      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MultiselectQuestion"
     } ]
   } ]
 }, {
-  "@id" : "_:genid130",
+  "@id" : "_:genid150",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid154"
+    }, {
+      "@id" : "_:genid152"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid152",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Assessment"
@@ -179,7 +300,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
   } ]
 }, {
-  "@id" : "_:genid132",
+  "@id" : "_:genid154",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
@@ -188,26 +309,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
   } ]
 }, {
-  "@id" : "_:genid133",
+  "@id" : "_:genid155",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid141"
+      "@id" : "_:genid163"
     }, {
-      "@id" : "_:genid135"
+      "@id" : "_:genid157"
     } ]
   } ]
 }, {
-  "@id" : "_:genid135",
+  "@id" : "_:genid157",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid136"
+    "@id" : "_:genid158"
   } ]
 }, {
-  "@id" : "_:genid136",
+  "@id" : "_:genid158",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -219,17 +340,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid14",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid141",
+  "@id" : "_:genid163",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -238,17 +349,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid142",
+  "@id" : "_:genid164",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid146"
+      "@id" : "_:genid168"
     }, {
-      "@id" : "_:genid144"
+      "@id" : "_:genid166"
     } ]
   } ]
 }, {
-  "@id" : "_:genid144",
+  "@id" : "_:genid166",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -257,7 +368,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid146",
+  "@id" : "_:genid168",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -266,17 +377,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid147",
+  "@id" : "_:genid169",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid151"
+      "@id" : "_:genid173"
     }, {
-      "@id" : "_:genid149"
+      "@id" : "_:genid171"
     } ]
   } ]
 }, {
-  "@id" : "_:genid149",
+  "@id" : "_:genid171",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AssessmentItem"
@@ -285,7 +396,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid151",
+  "@id" : "_:genid173",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -294,17 +405,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
   } ]
 }, {
-  "@id" : "_:genid152",
+  "@id" : "_:genid174",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid156"
+      "@id" : "_:genid178"
     }, {
-      "@id" : "_:genid154"
+      "@id" : "_:genid176"
     } ]
   } ]
 }, {
-  "@id" : "_:genid154",
+  "@id" : "_:genid176",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AssessmentItem"
@@ -313,7 +424,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/referrer"
   } ]
 }, {
-  "@id" : "_:genid156",
+  "@id" : "_:genid178",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/referrer"
@@ -322,7 +433,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
   } ]
 }, {
-  "@id" : "_:genid157",
+  "@id" : "_:genid179",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -331,26 +442,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Response"
   } ]
 }, {
-  "@id" : "_:genid158",
+  "@id" : "_:genid180",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid169"
+      "@id" : "_:genid191"
     }, {
-      "@id" : "_:genid160"
+      "@id" : "_:genid182"
     } ]
   } ]
 }, {
-  "@id" : "_:genid160",
+  "@id" : "_:genid182",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid161"
+    "@id" : "_:genid183"
   } ]
 }, {
-  "@id" : "_:genid161",
+  "@id" : "_:genid183",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -368,7 +479,17 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid169",
+  "@id" : "_:genid19",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireItem"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid191",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -377,27 +498,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid17",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Result"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Score"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid170",
+  "@id" : "_:genid192",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid174"
+      "@id" : "_:genid196"
     }, {
-      "@id" : "_:genid172"
+      "@id" : "_:genid194"
     } ]
   } ]
 }, {
-  "@id" : "_:genid172",
+  "@id" : "_:genid194",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -406,7 +517,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid174",
+  "@id" : "_:genid196",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -415,17 +526,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid175",
+  "@id" : "_:genid197",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid179"
+      "@id" : "_:genid201"
     }, {
-      "@id" : "_:genid177"
+      "@id" : "_:genid199"
     } ]
   } ]
 }, {
-  "@id" : "_:genid177",
+  "@id" : "_:genid199",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
@@ -434,7 +545,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid179",
+  "@id" : "_:genid201",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -443,7 +554,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid180",
+  "@id" : "_:genid202",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -452,7 +563,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
   } ]
 }, {
-  "@id" : "_:genid181",
+  "@id" : "_:genid203",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
@@ -461,17 +572,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Frame"
   } ]
 }, {
-  "@id" : "_:genid182",
+  "@id" : "_:genid204",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid186"
+      "@id" : "_:genid208"
     }, {
-      "@id" : "_:genid184"
+      "@id" : "_:genid206"
     } ]
   } ]
 }, {
-  "@id" : "_:genid184",
+  "@id" : "_:genid206",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
@@ -480,7 +591,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/assignable"
   } ]
 }, {
-  "@id" : "_:genid186",
+  "@id" : "_:genid208",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/assignable"
@@ -489,17 +600,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid187",
+  "@id" : "_:genid209",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid191"
+      "@id" : "_:genid213"
     }, {
-      "@id" : "_:genid189"
+      "@id" : "_:genid211"
     } ]
   } ]
 }, {
-  "@id" : "_:genid189",
+  "@id" : "_:genid211",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -508,7 +619,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/assignee"
   } ]
 }, {
-  "@id" : "_:genid191",
+  "@id" : "_:genid213",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/assignee"
@@ -517,7 +628,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid192",
+  "@id" : "_:genid214",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
@@ -526,17 +637,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
   } ]
 }, {
-  "@id" : "_:genid193",
+  "@id" : "_:genid215",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid197"
+      "@id" : "_:genid219"
     }, {
-      "@id" : "_:genid195"
+      "@id" : "_:genid217"
     } ]
   } ]
 }, {
-  "@id" : "_:genid195",
+  "@id" : "_:genid217",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -545,7 +656,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/commenter"
   } ]
 }, {
-  "@id" : "_:genid197",
+  "@id" : "_:genid219",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/commenter"
@@ -554,7 +665,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid198",
+  "@id" : "_:genid22",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitation"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid220",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/commentedOn"
@@ -563,27 +684,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid199",
+  "@id" : "_:genid221",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid203"
+      "@id" : "_:genid225"
     }, {
-      "@id" : "_:genid201"
+      "@id" : "_:genid223"
     } ]
   } ]
 }, {
-  "@id" : "_:genid20",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Query"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid201",
+  "@id" : "_:genid223",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
@@ -592,7 +703,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/items"
   } ]
 }, {
-  "@id" : "_:genid203",
+  "@id" : "_:genid225",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/items"
@@ -601,26 +712,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid204",
+  "@id" : "_:genid226",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid211"
+      "@id" : "_:genid233"
     }, {
-      "@id" : "_:genid206"
+      "@id" : "_:genid228"
     } ]
   } ]
 }, {
-  "@id" : "_:genid206",
+  "@id" : "_:genid228",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid207"
+    "@id" : "_:genid229"
   } ]
 }, {
-  "@id" : "_:genid207",
+  "@id" : "_:genid229",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -630,7 +741,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid211",
+  "@id" : "_:genid233",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -639,17 +750,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid212",
+  "@id" : "_:genid234",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid216"
+      "@id" : "_:genid238"
     }, {
-      "@id" : "_:genid214"
+      "@id" : "_:genid236"
     } ]
   } ]
 }, {
-  "@id" : "_:genid214",
+  "@id" : "_:genid236",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -658,7 +769,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid216",
+  "@id" : "_:genid238",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -667,26 +778,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid217",
+  "@id" : "_:genid239",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid224"
+      "@id" : "_:genid246"
     }, {
-      "@id" : "_:genid219"
+      "@id" : "_:genid241"
     } ]
   } ]
 }, {
-  "@id" : "_:genid219",
+  "@id" : "_:genid241",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid220"
+    "@id" : "_:genid242"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
   } ]
 }, {
-  "@id" : "_:genid220",
+  "@id" : "_:genid242",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -696,7 +807,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid224",
+  "@id" : "_:genid246",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -705,17 +816,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid225",
+  "@id" : "_:genid247",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid229"
+      "@id" : "_:genid251"
     }, {
-      "@id" : "_:genid227"
+      "@id" : "_:genid249"
     } ]
   } ]
 }, {
-  "@id" : "_:genid227",
+  "@id" : "_:genid249",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Frame"
@@ -724,7 +835,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/target"
   } ]
 }, {
-  "@id" : "_:genid229",
+  "@id" : "_:genid25",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/RatingScaleQuestion"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid251",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
@@ -733,21 +854,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid23",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Attempt"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MediaObject"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Response"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Session"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid230",
+  "@id" : "_:genid252",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -756,17 +863,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid231",
+  "@id" : "_:genid253",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid235"
+      "@id" : "_:genid257"
     }, {
-      "@id" : "_:genid233"
+      "@id" : "_:genid255"
     } ]
   } ]
 }, {
-  "@id" : "_:genid233",
+  "@id" : "_:genid255",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Thread"
@@ -775,7 +882,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/items"
   } ]
 }, {
-  "@id" : "_:genid235",
+  "@id" : "_:genid257",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/items"
@@ -784,26 +891,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid236",
+  "@id" : "_:genid258",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid243"
+      "@id" : "_:genid265"
     }, {
-      "@id" : "_:genid238"
+      "@id" : "_:genid260"
     } ]
   } ]
 }, {
-  "@id" : "_:genid238",
+  "@id" : "_:genid260",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid239"
+    "@id" : "_:genid261"
   } ]
 }, {
-  "@id" : "_:genid239",
+  "@id" : "_:genid261",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -813,7 +920,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid243",
+  "@id" : "_:genid265",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -822,17 +929,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid244",
+  "@id" : "_:genid266",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid248"
+      "@id" : "_:genid270"
     }, {
-      "@id" : "_:genid246"
+      "@id" : "_:genid268"
     } ]
   } ]
 }, {
-  "@id" : "_:genid246",
+  "@id" : "_:genid268",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -841,7 +948,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid248",
+  "@id" : "_:genid270",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -850,17 +957,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid249",
+  "@id" : "_:genid271",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid253"
+      "@id" : "_:genid275"
     }, {
-      "@id" : "_:genid251"
+      "@id" : "_:genid273"
     } ]
   } ]
 }, {
-  "@id" : "_:genid251",
+  "@id" : "_:genid273",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Forum"
@@ -869,7 +976,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid253",
+  "@id" : "_:genid275",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -878,17 +985,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid254",
+  "@id" : "_:genid276",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid258"
+      "@id" : "_:genid280"
     }, {
-      "@id" : "_:genid256"
+      "@id" : "_:genid278"
     } ]
   } ]
 }, {
-  "@id" : "_:genid256",
+  "@id" : "_:genid278",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#hasValue" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actions/Graded"
@@ -897,7 +1004,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ]
 }, {
-  "@id" : "_:genid258",
+  "@id" : "_:genid28",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Result"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Score"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid280",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -906,26 +1023,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid259",
+  "@id" : "_:genid281",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid266"
+      "@id" : "_:genid288"
     }, {
-      "@id" : "_:genid261"
+      "@id" : "_:genid283"
     } ]
   } ]
 }, {
-  "@id" : "_:genid261",
+  "@id" : "_:genid283",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid262"
+    "@id" : "_:genid284"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid262",
+  "@id" : "_:genid284",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -935,7 +1052,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid266",
+  "@id" : "_:genid288",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -944,17 +1061,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid267",
+  "@id" : "_:genid289",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid271"
+      "@id" : "_:genid293"
     }, {
-      "@id" : "_:genid269"
+      "@id" : "_:genid291"
     } ]
   } ]
 }, {
-  "@id" : "_:genid269",
+  "@id" : "_:genid291",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
@@ -963,7 +1080,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid271",
+  "@id" : "_:genid293",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -972,7 +1089,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid272",
+  "@id" : "_:genid294",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -981,26 +1098,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Score"
   } ]
 }, {
-  "@id" : "_:genid273",
+  "@id" : "_:genid295",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid297"
+      "@id" : "_:genid319"
     }, {
-      "@id" : "_:genid275"
+      "@id" : "_:genid297"
     } ]
   } ]
 }, {
-  "@id" : "_:genid275",
+  "@id" : "_:genid297",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid276"
+    "@id" : "_:genid298"
   } ]
 }, {
-  "@id" : "_:genid276",
+  "@id" : "_:genid298",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -1044,21 +1161,17 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid28",
+  "@id" : "_:genid31",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/AggregateMeasure"
+      "@id" : "http://purl.imsglobal.org/caliper/Query"
     }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Attempt"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Response"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Session"
+      "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
     } ]
   } ]
 }, {
-  "@id" : "_:genid297",
+  "@id" : "_:genid319",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -1067,17 +1180,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid298",
+  "@id" : "_:genid320",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid302"
+      "@id" : "_:genid324"
     }, {
-      "@id" : "_:genid300"
+      "@id" : "_:genid322"
     } ]
   } ]
 }, {
-  "@id" : "_:genid300",
+  "@id" : "_:genid322",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -1086,7 +1199,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid302",
+  "@id" : "_:genid324",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -1095,17 +1208,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid303",
+  "@id" : "_:genid325",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid307"
+      "@id" : "_:genid329"
     }, {
-      "@id" : "_:genid305"
+      "@id" : "_:genid327"
     } ]
   } ]
 }, {
-  "@id" : "_:genid305",
+  "@id" : "_:genid327",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/MediaObject"
@@ -1114,7 +1227,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid307",
+  "@id" : "_:genid329",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -1123,7 +1236,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid308",
+  "@id" : "_:genid330",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
@@ -1132,17 +1245,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/MediaLocation"
   } ]
 }, {
-  "@id" : "_:genid309",
+  "@id" : "_:genid331",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid313"
+      "@id" : "_:genid335"
     }, {
-      "@id" : "_:genid311"
+      "@id" : "_:genid333"
     } ]
   } ]
 }, {
-  "@id" : "_:genid311",
+  "@id" : "_:genid333",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -1151,7 +1264,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/member"
   } ]
 }, {
-  "@id" : "_:genid313",
+  "@id" : "_:genid335",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/member"
@@ -1160,17 +1273,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid314",
+  "@id" : "_:genid336",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid318"
+      "@id" : "_:genid340"
     }, {
-      "@id" : "_:genid316"
+      "@id" : "_:genid338"
     } ]
   } ]
 }, {
-  "@id" : "_:genid316",
+  "@id" : "_:genid338",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Organization"
@@ -1179,7 +1292,19 @@
     "@id" : "http://purl.imsglobal.org/caliper/organization"
   } ]
 }, {
-  "@id" : "_:genid318",
+  "@id" : "_:genid34",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/RatingScaleResponse"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid340",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/organization"
@@ -1188,17 +1313,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid319",
+  "@id" : "_:genid341",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid323"
+      "@id" : "_:genid345"
     }, {
-      "@id" : "_:genid321"
+      "@id" : "_:genid343"
     } ]
   } ]
 }, {
-  "@id" : "_:genid321",
+  "@id" : "_:genid343",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Thread"
@@ -1207,7 +1332,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
   } ]
 }, {
-  "@id" : "_:genid323",
+  "@id" : "_:genid345",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
@@ -1216,26 +1341,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid324",
+  "@id" : "_:genid346",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid332"
+      "@id" : "_:genid354"
     }, {
-      "@id" : "_:genid326"
+      "@id" : "_:genid348"
     } ]
   } ]
 }, {
-  "@id" : "_:genid326",
+  "@id" : "_:genid348",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid327"
+    "@id" : "_:genid349"
   } ]
 }, {
-  "@id" : "_:genid327",
+  "@id" : "_:genid349",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -1247,17 +1372,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid33",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Entity"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Event"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid332",
+  "@id" : "_:genid354",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -1266,17 +1381,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid333",
+  "@id" : "_:genid355",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid337"
+      "@id" : "_:genid359"
     }, {
-      "@id" : "_:genid335"
+      "@id" : "_:genid357"
     } ]
   } ]
 }, {
-  "@id" : "_:genid335",
+  "@id" : "_:genid357",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -1285,7 +1400,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid337",
+  "@id" : "_:genid359",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -1294,17 +1409,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid338",
+  "@id" : "_:genid360",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid342"
+      "@id" : "_:genid364"
     }, {
-      "@id" : "_:genid340"
+      "@id" : "_:genid362"
     } ]
   } ]
 }, {
-  "@id" : "_:genid340",
+  "@id" : "_:genid362",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Message"
@@ -1313,7 +1428,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid342",
+  "@id" : "_:genid364",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -1322,17 +1437,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid343",
+  "@id" : "_:genid365",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid347"
+      "@id" : "_:genid369"
     }, {
-      "@id" : "_:genid345"
+      "@id" : "_:genid367"
     } ]
   } ]
 }, {
-  "@id" : "_:genid345",
+  "@id" : "_:genid367",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#hasValue" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actions/NavigatedTo"
@@ -1341,136 +1456,13 @@
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ]
 }, {
-  "@id" : "_:genid347",
+  "@id" : "_:genid369",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Action"
-  } ]
-}, {
-  "@id" : "_:genid348",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid352"
-    }, {
-      "@id" : "_:genid350"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid350",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ]
-}, {
-  "@id" : "_:genid352",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid353",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid360"
-    }, {
-      "@id" : "_:genid355"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid355",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid356"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid356",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid36",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Score"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid360",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid361",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid368"
-    }, {
-      "@id" : "_:genid363"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid363",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid364"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/referrer"
-  } ]
-}, {
-  "@id" : "_:genid364",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid368",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/referrer"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid369",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/target"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Frame"
   } ]
 }, {
   "@id" : "_:genid370",
@@ -1485,20 +1477,20 @@
 }, {
   "@id" : "_:genid372",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#hasValue" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actions/Graded"
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
   "@id" : "_:genid374",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Action"
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
   "@id" : "_:genid375",
@@ -1517,10 +1509,137 @@
     "@id" : "_:genid378"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
+    "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
   "@id" : "_:genid378",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid38",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Attempt"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MediaObject"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Response"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Session"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid382",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid383",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid390"
+    }, {
+      "@id" : "_:genid385"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid385",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "_:genid386"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/referrer"
+  } ]
+}, {
+  "@id" : "_:genid386",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid390",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/referrer"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid391",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/target"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Frame"
+  } ]
+}, {
+  "@id" : "_:genid392",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid396"
+    }, {
+      "@id" : "_:genid394"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid394",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#hasValue" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actions/Graded"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ]
+}, {
+  "@id" : "_:genid396",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid397",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid404"
+    }, {
+      "@id" : "_:genid399"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid399",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "_:genid400"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid400",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -1530,7 +1649,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid382",
+  "@id" : "_:genid404",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -1539,17 +1658,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid383",
+  "@id" : "_:genid405",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid387"
+      "@id" : "_:genid409"
     }, {
-      "@id" : "_:genid385"
+      "@id" : "_:genid407"
     } ]
   } ]
 }, {
-  "@id" : "_:genid385",
+  "@id" : "_:genid407",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
@@ -1558,7 +1677,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/generated"
   } ]
 }, {
-  "@id" : "_:genid387",
+  "@id" : "_:genid409",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -1567,27 +1686,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid388",
+  "@id" : "_:genid410",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid392"
+      "@id" : "_:genid414"
     }, {
-      "@id" : "_:genid390"
+      "@id" : "_:genid412"
     } ]
   } ]
 }, {
-  "@id" : "_:genid39",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid390",
+  "@id" : "_:genid412",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
@@ -1596,7 +1705,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid392",
+  "@id" : "_:genid414",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -1605,75 +1714,36 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid393",
+  "@id" : "_:genid415",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid397"
+      "@id" : "_:genid422"
     }, {
-      "@id" : "_:genid395"
+      "@id" : "_:genid417"
     } ]
   } ]
 }, {
-  "@id" : "_:genid395",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/rater"
-  } ]
-}, {
-  "@id" : "_:genid397",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/rater"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid398",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/rated"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid399",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid407"
-    }, {
-      "@id" : "_:genid401"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid401",
+  "@id" : "_:genid417",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid402"
+    "@id" : "_:genid418"
   } ]
 }, {
-  "@id" : "_:genid402",
+  "@id" : "_:genid418",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/NavigatedTo"
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Started"
     }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Searched"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Viewed"
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Submitted"
     } ]
   } ]
 }, {
-  "@id" : "_:genid407",
+  "@id" : "_:genid422",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -1682,17 +1752,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid408",
+  "@id" : "_:genid423",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid412"
+      "@id" : "_:genid427"
     }, {
-      "@id" : "_:genid410"
+      "@id" : "_:genid425"
     } ]
   } ]
 }, {
-  "@id" : "_:genid410",
+  "@id" : "_:genid425",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -1701,7 +1771,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid412",
+  "@id" : "_:genid427",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -1710,54 +1780,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid413",
+  "@id" : "_:genid428",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid417"
+      "@id" : "_:genid432"
     }, {
-      "@id" : "_:genid415"
+      "@id" : "_:genid430"
     } ]
   } ]
 }, {
-  "@id" : "_:genid415",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid417",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid418",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/target"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Frame"
-  } ]
-}, {
-  "@id" : "_:genid419",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid438"
-    }, {
-      "@id" : "_:genid421"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid42",
+  "@id" : "_:genid43",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -1771,22 +1804,305 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid421",
+  "@id" : "_:genid430",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Questionnaire"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid432",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid433",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid441"
+    }, {
+      "@id" : "_:genid435"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid435",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid422"
+    "@id" : "_:genid436"
   } ]
 }, {
-  "@id" : "_:genid422",
+  "@id" : "_:genid436",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/actions/Archived"
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Completed"
     }, {
-      "@id" : "http://purl.imsglobal.org/actions/Restored"
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Skipped"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Started"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid441",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid442",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid446"
+    }, {
+      "@id" : "_:genid444"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid444",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid446",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid447",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid451"
+    }, {
+      "@id" : "_:genid449"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid449",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireItem"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid451",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid452",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/generated"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Response"
+  } ]
+}, {
+  "@id" : "_:genid453",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid457"
+    }, {
+      "@id" : "_:genid455"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid455",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/rater"
+  } ]
+}, {
+  "@id" : "_:genid457",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/rater"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid458",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/rated"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid459",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid467"
+    }, {
+      "@id" : "_:genid461"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid461",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid462"
+  } ]
+}, {
+  "@id" : "_:genid462",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/NavigatedTo"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Searched"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Viewed"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid467",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid468",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid472"
+    }, {
+      "@id" : "_:genid470"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid470",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid472",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid473",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid477"
+    }, {
+      "@id" : "_:genid475"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid475",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid477",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid478",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/target"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Frame"
+  } ]
+}, {
+  "@id" : "_:genid479",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid498"
+    }, {
+      "@id" : "_:genid481"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid48",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Entity"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Event"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid481",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid482"
+  } ]
+}, {
+  "@id" : "_:genid482",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Archived"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Copied"
     }, {
@@ -1804,6 +2120,8 @@
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Published"
     }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Restored"
+    }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Retrieved"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Saved"
@@ -1814,344 +2132,23 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid438",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Action"
-  } ]
-}, {
-  "@id" : "_:genid439",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid443"
-    }, {
-      "@id" : "_:genid441"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid441",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ]
-}, {
-  "@id" : "_:genid443",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid444",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid448"
-    }, {
-      "@id" : "_:genid446"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid446",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid448",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid449",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/generated"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid450",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid454"
-    }, {
-      "@id" : "_:genid452"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid452",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#hasValue" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actions/Searched"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ]
-}, {
-  "@id" : "_:genid454",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Action"
-  } ]
-}, {
-  "@id" : "_:genid455",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid459"
-    }, {
-      "@id" : "_:genid457"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid457",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ]
-}, {
-  "@id" : "_:genid459",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid460",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/generated"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
-  } ]
-}, {
-  "@id" : "_:genid461",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid465"
-    }, {
-      "@id" : "_:genid463"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid463",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/user"
-  } ]
-}, {
-  "@id" : "_:genid465",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/user"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid466",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid474"
-    }, {
-      "@id" : "_:genid468"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid468",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid469"
-  } ]
-}, {
-  "@id" : "_:genid469",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#oneOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/LoggedIn"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/LoggedOut"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/TimedOut"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid47",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Entity"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Event"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid474",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Action"
-  } ]
-}, {
-  "@id" : "_:genid475",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid482"
-    }, {
-      "@id" : "_:genid477"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid477",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid478"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ]
-}, {
-  "@id" : "_:genid478",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Person"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid482",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid483",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid490"
-    }, {
-      "@id" : "_:genid485"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid485",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid486"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid486",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Session"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid490",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid491",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid498"
-    }, {
-      "@id" : "_:genid493"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid493",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid494"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/referrer"
-  } ]
-}, {
-  "@id" : "_:genid494",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
-    } ]
-  } ]
-}, {
   "@id" : "_:genid498",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/referrer"
+    "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
   "@id" : "_:genid499",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/target"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid503"
+    }, {
+      "@id" : "_:genid501"
+    } ]
   } ]
 }, {
   "@id" : "_:genid5",
@@ -2164,77 +2161,76 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid50",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/MultipleChoiceResponse"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/TrueFalseResponse"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid500",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid504"
-    }, {
-      "@id" : "_:genid502"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid502",
+  "@id" : "_:genid501",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Forum"
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid503",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
   "@id" : "_:genid504",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid505",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid509"
+      "@id" : "_:genid508"
     }, {
-      "@id" : "_:genid507"
+      "@id" : "_:genid506"
     } ]
   } ]
 }, {
-  "@id" : "_:genid507",
+  "@id" : "_:genid506",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Message"
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/items"
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid508",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
   "@id" : "_:genid509",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/items"
+    "@id" : "http://purl.imsglobal.org/caliper/generated"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid51",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/DateTimeQuestion"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/NumericScale"
+    } ]
   } ]
 }, {
   "@id" : "_:genid510",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid517"
+      "@id" : "_:genid514"
     }, {
       "@id" : "_:genid512"
     } ]
@@ -2242,270 +2238,119 @@
 }, {
   "@id" : "_:genid512",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#hasValue" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actions/Searched"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ]
+}, {
+  "@id" : "_:genid514",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid513"
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid513",
+  "@id" : "_:genid515",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/MarkedAsRead"
+      "@id" : "_:genid519"
     }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/MarkedAsUnread"
+      "@id" : "_:genid517"
     } ]
   } ]
 }, {
   "@id" : "_:genid517",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
   } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid518",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid522"
-    }, {
-      "@id" : "_:genid520"
-    } ]
+  "@id" : "_:genid519",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
   "@id" : "_:genid520",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ]
-}, {
-  "@id" : "_:genid522",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid523",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid527"
-    }, {
-      "@id" : "_:genid525"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid525",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Thread"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid527",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-  } ]
-}, {
-  "@id" : "_:genid528",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid535"
-    }, {
-      "@id" : "_:genid530"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid53",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/FillinBlankResponse"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MultipleResponseResponse"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SelectTextResponse"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid530",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid531"
-  } ]
-}, {
-  "@id" : "_:genid531",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#oneOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/actions/Launched"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Returned"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid535",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Action"
-  } ]
-}, {
-  "@id" : "_:genid536",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid540"
-    }, {
-      "@id" : "_:genid538"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid538",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ]
-}, {
-  "@id" : "_:genid540",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid541",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid545"
-    }, {
-      "@id" : "_:genid543"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid543",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid545",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid546",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid553"
-    }, {
-      "@id" : "_:genid548"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid548",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid549"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/target"
-  } ]
-}, {
-  "@id" : "_:genid549",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Link"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/LtiLink"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid553",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/target"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid554",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+    "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
   } ]
 }, {
-  "@id" : "_:genid555",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/LtiSession"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/federatedSession"
-  } ]
-}, {
-  "@id" : "_:genid556",
+  "@id" : "_:genid521",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid560"
+      "@id" : "_:genid525"
     }, {
-      "@id" : "_:genid558"
+      "@id" : "_:genid523"
     } ]
   } ]
 }, {
-  "@id" : "_:genid558",
+  "@id" : "_:genid523",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#hasValue" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actions/Used"
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
+    "@id" : "http://purl.imsglobal.org/caliper/user"
   } ]
 }, {
-  "@id" : "_:genid560",
+  "@id" : "_:genid525",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/user"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid526",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid534"
+    }, {
+      "@id" : "_:genid528"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid528",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid529"
+  } ]
+}, {
+  "@id" : "_:genid529",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/LoggedIn"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/LoggedOut"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/TimedOut"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid534",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -2514,26 +2359,46 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid561",
+  "@id" : "_:genid535",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid565"
+      "@id" : "_:genid542"
     }, {
-      "@id" : "_:genid563"
+      "@id" : "_:genid537"
     } ]
   } ]
 }, {
-  "@id" : "_:genid563",
+  "@id" : "_:genid537",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
+    "@id" : "_:genid538"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid565",
+  "@id" : "_:genid538",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Person"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid54",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Score"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid542",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -2542,26 +2407,64 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid566",
+  "@id" : "_:genid543",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid570"
+      "@id" : "_:genid550"
     }, {
-      "@id" : "_:genid568"
+      "@id" : "_:genid545"
     } ]
   } ]
 }, {
-  "@id" : "_:genid568",
+  "@id" : "_:genid545",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+    "@id" : "_:genid546"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid57",
+  "@id" : "_:genid546",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Session"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid550",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid551",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid558"
+    }, {
+      "@id" : "_:genid553"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid553",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "_:genid554"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/referrer"
+  } ]
+}, {
+  "@id" : "_:genid554",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -2571,44 +2474,92 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid570",
+  "@id" : "_:genid558",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
+    "@id" : "http://purl.imsglobal.org/caliper/referrer"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid571",
+  "@id" : "_:genid559",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid572",
+  "@id" : "_:genid560",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid576"
+      "@id" : "_:genid564"
     }, {
-      "@id" : "_:genid574"
+      "@id" : "_:genid562"
     } ]
   } ]
 }, {
-  "@id" : "_:genid574",
+  "@id" : "_:genid562",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#hasValue" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actions/Viewed"
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Questionnaire"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
+    "@id" : "http://purl.imsglobal.org/caliper/items"
   } ]
 }, {
-  "@id" : "_:genid576",
+  "@id" : "_:genid564",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/items"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid565",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid572"
+    }, {
+      "@id" : "_:genid567"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid567",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid568"
+  } ]
+}, {
+  "@id" : "_:genid568",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/OptedIn"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/OptedOut"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid57",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/DateTimeQuestion"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/NumericScale"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid572",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -2617,17 +2568,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid577",
+  "@id" : "_:genid573",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid581"
+      "@id" : "_:genid577"
     }, {
-      "@id" : "_:genid579"
+      "@id" : "_:genid575"
     } ]
   } ]
 }, {
-  "@id" : "_:genid579",
+  "@id" : "_:genid575",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -2636,7 +2587,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid581",
+  "@id" : "_:genid577",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -2645,17 +2596,624 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid582",
+  "@id" : "_:genid578",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid586"
+      "@id" : "_:genid582"
     }, {
-      "@id" : "_:genid584"
+      "@id" : "_:genid580"
     } ]
   } ]
 }, {
-  "@id" : "_:genid584",
+  "@id" : "_:genid580",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Survey"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid582",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid583",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid591"
+    }, {
+      "@id" : "_:genid585"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid585",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid586"
+  } ]
+}, {
+  "@id" : "_:genid586",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Accepted"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Declined"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Sent"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid591",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid592",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid596"
+    }, {
+      "@id" : "_:genid594"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid594",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid596",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid597",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid601"
+    }, {
+      "@id" : "_:genid599"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid599",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitation"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid60",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid601",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid602",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid606"
+    }, {
+      "@id" : "_:genid604"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid604",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Forum"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
+  } ]
+}, {
+  "@id" : "_:genid606",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid607",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid611"
+    }, {
+      "@id" : "_:genid609"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid609",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Message"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/items"
+  } ]
+}, {
+  "@id" : "_:genid611",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/items"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid612",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid619"
+    }, {
+      "@id" : "_:genid614"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid614",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid615"
+  } ]
+}, {
+  "@id" : "_:genid615",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/MarkedAsRead"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/MarkedAsUnread"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid619",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid620",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid624"
+    }, {
+      "@id" : "_:genid622"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid622",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid624",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid625",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid629"
+    }, {
+      "@id" : "_:genid627"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid627",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Thread"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid629",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ]
+}, {
+  "@id" : "_:genid63",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/AggregateMeasure"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Attempt"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Response"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Session"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid630",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid637"
+    }, {
+      "@id" : "_:genid632"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid632",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid633"
+  } ]
+}, {
+  "@id" : "_:genid633",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Launched"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Returned"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid637",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid638",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid642"
+    }, {
+      "@id" : "_:genid640"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid640",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid642",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid643",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid647"
+    }, {
+      "@id" : "_:genid645"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid645",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid647",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid648",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid655"
+    }, {
+      "@id" : "_:genid650"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid650",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "_:genid651"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/target"
+  } ]
+}, {
+  "@id" : "_:genid651",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Link"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/LtiLink"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid655",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/target"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid656",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/generated"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ]
+}, {
+  "@id" : "_:genid657",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/LtiSession"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/federatedSession"
+  } ]
+}, {
+  "@id" : "_:genid658",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid662"
+    }, {
+      "@id" : "_:genid660"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid660",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#hasValue" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actions/Used"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ]
+}, {
+  "@id" : "_:genid662",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid663",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid667"
+    }, {
+      "@id" : "_:genid665"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid665",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid667",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid668",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid672"
+    }, {
+      "@id" : "_:genid670"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid670",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ]
+}, {
+  "@id" : "_:genid672",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid673",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/target"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ]
+}, {
+  "@id" : "_:genid674",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid678"
+    }, {
+      "@id" : "_:genid676"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid676",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#hasValue" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actions/Viewed"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ]
+}, {
+  "@id" : "_:genid678",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Action"
+  } ]
+}, {
+  "@id" : "_:genid679",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid683"
+    }, {
+      "@id" : "_:genid681"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid68",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Entity"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Event"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid681",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ]
+}, {
+  "@id" : "_:genid683",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/actor"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid684",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid688"
+    }, {
+      "@id" : "_:genid686"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid686",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
@@ -2664,7 +3222,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid586",
+  "@id" : "_:genid688",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -2673,7 +3231,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid587",
+  "@id" : "_:genid689",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
@@ -2682,17 +3240,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Frame"
   } ]
 }, {
-  "@id" : "_:genid588",
+  "@id" : "_:genid690",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid592"
+      "@id" : "_:genid694"
     }, {
-      "@id" : "_:genid590"
+      "@id" : "_:genid692"
     } ]
   } ]
 }, {
-  "@id" : "_:genid590",
+  "@id" : "_:genid692",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/epubChapter"
@@ -2701,7 +3259,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
   } ]
 }, {
-  "@id" : "_:genid592",
+  "@id" : "_:genid694",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
@@ -2710,7 +3268,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid593",
+  "@id" : "_:genid695",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2730,17 +3288,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid60",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid64"
-    }, {
-      "@id" : "_:genid62"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid601",
+  "@id" : "_:genid703",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2780,11 +3328,25 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid619",
+  "@id" : "_:genid71",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/MultipleChoiceResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/OpenEndedResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/TrueFalseResponse"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid721",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
       "@id" : "http://purl.imsglobal.org/caliper/Agent"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/AggregateMeasure"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/Annotation"
     }, {
@@ -2818,97 +3380,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid62",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/AggregateMeasure"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/items"
-  } ]
-}, {
-  "@id" : "_:genid636",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
-  "http://www.w3.org/2002/07/owl#members" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Agent"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Annotation"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Attempt"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/LearningObjective"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Link"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Membership"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Query"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Response"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Result"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Score"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Session"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid64",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/items"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid65",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid69"
-    }, {
-      "@id" : "_:genid67"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid650",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
-  "http://www.w3.org/2002/07/owl#members" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Agent"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Annotation"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Attempt"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/LearningObjective"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Membership"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Query"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Response"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Result"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Score"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Session"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid663",
+  "@id" : "_:genid739",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2952,21 +3424,62 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid67",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/annotated"
+  "@id" : "_:genid75",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/FillinBlankResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MultipleResponseResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SelectTextResponse"
+    } ]
   } ]
 }, {
-  "@id" : "_:genid683",
+  "@id" : "_:genid759",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
+      "@id" : "http://purl.imsglobal.org/caliper/Assessment"
     }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Forum"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Questionnaire"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Thread"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid764",
+  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
+  "http://www.w3.org/2002/07/owl#members" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/AudioObject"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/ImageObject"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/VideoObject"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid768",
+  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
+  "http://www.w3.org/2002/07/owl#members" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/BookmarkAnnotation"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/HighlightAnnotation"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SharedAnnotation"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/TagAnnotation"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid773",
+  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
+  "http://www.w3.org/2002/07/owl#members" : [ {
+    "@list" : [ {
       "@id" : "http://purl.imsglobal.org/caliper/Chapter"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
@@ -2987,90 +3500,31 @@
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/Question"
     }, {
-      "@id" : "http://purl.imsglobal.org/caliper/WebPage"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid69",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/annotated"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
-  "@id" : "_:genid696",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
-  "http://www.w3.org/2002/07/owl#members" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
+      "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireItem"
     }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Chapter"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Document"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Frame"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/LtiLink"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MediaLocation"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MediaObject"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Message"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Page"
+      "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitation"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/WebPage"
     } ]
   } ]
 }, {
-  "@id" : "_:genid70",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid74"
-    }, {
-      "@id" : "_:genid72"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid707",
+  "@id" : "_:genid787",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/AudioObject"
+      "@id" : "http://purl.imsglobal.org/caliper/DateTimeResponse"
     }, {
-      "@id" : "http://purl.imsglobal.org/caliper/ImageObject"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/VideoObject"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid711",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
-  "http://www.w3.org/2002/07/owl#members" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/BookmarkAnnotation"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/HighlightAnnotation"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/SharedAnnotation"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/TagAnnotation"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid716",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
-  "http://www.w3.org/2002/07/owl#members" : [ {
-    "@list" : [ {
       "@id" : "http://purl.imsglobal.org/caliper/FillinBlankResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectResponse"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/MultipleChoiceResponse"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/MultipleResponseResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/OpenEndedResponse"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/RatingScaleResponse"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/SelectTextResponse"
     }, {
@@ -3078,16 +3532,17 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid72",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/annotator"
+  "@id" : "_:genid79",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+    } ]
   } ]
 }, {
-  "@id" : "_:genid722",
+  "@id" : "_:genid797",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3099,7 +3554,17 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid726",
+  "@id" : "_:genid8",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#unionOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/Entity"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Event"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid801",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3111,7 +3576,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid730",
+  "@id" : "_:genid805",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3133,7 +3598,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid739",
+  "@id" : "_:genid814",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
   "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
     "@list" : [ {
@@ -3143,16 +3608,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid74",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/annotator"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid742",
+  "@id" : "_:genid817",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
   "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
     "@list" : [ {
@@ -3174,168 +3630,107 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid75",
+  "@id" : "_:genid82",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
+      "@id" : "_:genid86"
+    }, {
       "@id" : "_:genid84"
-    }, {
-      "@id" : "_:genid77"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid77",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid78"
-  } ]
-}, {
-  "@id" : "_:genid78",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#oneOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Bookmarked"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Highlighted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Shared"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Tagged"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid8",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#unionOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/Entity"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/Event"
     } ]
   } ]
 }, {
   "@id" : "_:genid84",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Action"
-  } ]
-}, {
-  "@id" : "_:genid85",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid89"
-    }, {
-      "@id" : "_:genid87"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid87",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
+    "@id" : "http://purl.imsglobal.org/caliper/AggregateMeasure"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
+    "@id" : "http://purl.imsglobal.org/caliper/items"
   } ]
 }, {
-  "@id" : "_:genid89",
+  "@id" : "_:genid86",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/actor"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid90",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid94"
-    }, {
-      "@id" : "_:genid92"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid92",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid94",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
+    "@id" : "http://purl.imsglobal.org/caliper/items"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid95",
+  "@id" : "_:genid87",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid91"
+    }, {
+      "@id" : "_:genid89"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid89",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/annotated"
+  } ]
+}, {
+  "@id" : "_:genid91",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/generated"
+    "@id" : "http://purl.imsglobal.org/caliper/annotated"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Annotation"
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid92",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid96"
+    }, {
+      "@id" : "_:genid94"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid94",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/annotator"
   } ]
 }, {
   "@id" : "_:genid96",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/target"
+    "@id" : "http://purl.imsglobal.org/caliper/annotator"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Frame"
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
   "@id" : "_:genid97",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
+      "@id" : "_:genid106"
     }, {
-      "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
+      "@id" : "_:genid99"
     } ]
   } ]
 }, {
-  "@id" : "http://purl.imsglobal.org/actions/Archived",
-  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "Put into an archive. The Archived action signals that a resource has been put into long-term storage. Inverse of Restored."
+  "@id" : "_:genid99",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "http://wordnet-rdf.princeton.edu/wn31/201387292-v"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "Archived"
-  } ]
-}, {
-  "@id" : "http://purl.imsglobal.org/actions/Launched",
-  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "Get going; give impetus to."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "href=\"http://wordnet-rdf.princeton.edu/wn31/01515196-v"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "Launched"
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid100"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/actions/Published",
@@ -3350,34 +3745,6 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Published"
-  } ]
-}, {
-  "@id" : "http://purl.imsglobal.org/actions/Restored",
-  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "Return to its original or usable and functioning condition. Inverse of Archived."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "http://wordnet-rdf.princeton.edu/wn31/202558146-v"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "Restored"
-  } ]
-}, {
-  "@id" : "http://purl.imsglobal.org/actions/Returned",
-  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "Go or come back to place, condition, or activity where one has been before."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "http://wordnet-rdf.princeton.edu/wn31/01515196-v"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "Returned"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/",
@@ -3466,7 +3833,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Collection"
   }, {
-    "@id" : "_:genid60"
+    "@id" : "_:genid82"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Annotation",
@@ -3485,9 +3852,9 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   }, {
-    "@id" : "_:genid65"
+    "@id" : "_:genid87"
   }, {
-    "@id" : "_:genid70"
+    "@id" : "_:genid92"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AnnotationEvent",
@@ -3506,15 +3873,15 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid75"
+    "@id" : "_:genid97"
   }, {
-    "@id" : "_:genid85"
+    "@id" : "_:genid107"
   }, {
-    "@id" : "_:genid90"
+    "@id" : "_:genid112"
   }, {
-    "@id" : "_:genid95"
+    "@id" : "_:genid117"
   }, {
-    "@id" : "_:genid96"
+    "@id" : "_:genid118"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AnnotationProfile",
@@ -3545,9 +3912,9 @@
     "@value" : "Assessment"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
-    "@id" : "_:genid97"
+    "@id" : "_:genid119"
   }, {
-    "@id" : "_:genid100"
+    "@id" : "_:genid122"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AssessmentEvent",
@@ -3566,13 +3933,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid105"
-  }, {
-    "@id" : "_:genid117"
-  }, {
-    "@id" : "_:genid122"
-  }, {
     "@id" : "_:genid127"
+  }, {
+    "@id" : "_:genid139"
+  }, {
+    "@id" : "_:genid144"
+  }, {
+    "@id" : "_:genid149"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AssessmentItem",
@@ -3591,7 +3958,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
   }, {
-    "@id" : "_:genid128"
+    "@id" : "_:genid150"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AssessmentItemEvent",
@@ -3610,15 +3977,15 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid133"
+    "@id" : "_:genid155"
   }, {
-    "@id" : "_:genid142"
+    "@id" : "_:genid164"
   }, {
-    "@id" : "_:genid147"
+    "@id" : "_:genid169"
   }, {
-    "@id" : "_:genid152"
+    "@id" : "_:genid174"
   }, {
-    "@id" : "_:genid157"
+    "@id" : "_:genid179"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AssessmentProfile",
@@ -3671,15 +4038,15 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid158"
-  }, {
-    "@id" : "_:genid170"
-  }, {
-    "@id" : "_:genid175"
-  }, {
     "@id" : "_:genid180"
   }, {
-    "@id" : "_:genid181"
+    "@id" : "_:genid192"
+  }, {
+    "@id" : "_:genid197"
+  }, {
+    "@id" : "_:genid202"
+  }, {
+    "@id" : "_:genid203"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AssignableProfile",
@@ -3712,11 +4079,11 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   }, {
-    "@id" : "_:genid182"
+    "@id" : "_:genid204"
   }, {
-    "@id" : "_:genid187"
+    "@id" : "_:genid209"
   }, {
-    "@id" : "_:genid192"
+    "@id" : "_:genid214"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/AudioObject",
@@ -3803,9 +4170,9 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   }, {
-    "@id" : "_:genid193"
+    "@id" : "_:genid215"
   }, {
-    "@id" : "_:genid198"
+    "@id" : "_:genid220"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/CourseOffering",
@@ -3845,6 +4212,40 @@
     "@id" : "http://purl.imsglobal.org/caliper/CourseOffering"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/DateTimeQuestion",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper DateTimeQuestion represents a closed-end question type with the response provided in a date and time format."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "DateTimeQuestion"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Question"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/DateTimeResponse",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper DateTimeResponse represents a respondent's response to a DateTimeQuestion."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "DateTimeResponse"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Response"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/DigitalResource",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -3880,7 +4281,7 @@
   }, {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   }, {
-    "@id" : "_:genid199"
+    "@id" : "_:genid221"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Document",
@@ -3958,15 +4359,15 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid204"
+    "@id" : "_:genid226"
   }, {
-    "@id" : "_:genid212"
+    "@id" : "_:genid234"
   }, {
-    "@id" : "_:genid217"
+    "@id" : "_:genid239"
   }, {
-    "@id" : "_:genid225"
+    "@id" : "_:genid247"
   }, {
-    "@id" : "_:genid230"
+    "@id" : "_:genid252"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/FeedbackProfile",
@@ -4016,7 +4417,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
   }, {
-    "@id" : "_:genid231"
+    "@id" : "_:genid253"
   } ],
   "http://www.w3.org/2002/07/owl#disjointWith" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Thread"
@@ -4038,11 +4439,11 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid236"
+    "@id" : "_:genid258"
   }, {
-    "@id" : "_:genid244"
+    "@id" : "_:genid266"
   }, {
-    "@id" : "_:genid249"
+    "@id" : "_:genid271"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ForumProfile",
@@ -4106,13 +4507,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid254"
+    "@id" : "_:genid276"
   }, {
-    "@id" : "_:genid259"
+    "@id" : "_:genid281"
   }, {
-    "@id" : "_:genid267"
+    "@id" : "_:genid289"
   }, {
-    "@id" : "_:genid272"
+    "@id" : "_:genid294"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/GradingProfile",
@@ -4235,7 +4636,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "The LtiLink entity represents a digital resource that must be retrieved from an external tool application via an LTI request message. It is, effectively, a Digital Resource that must use LTI for access."
+    "@value" : "The Caliper LtiLink entity represents a digital resource that must be retrieved from an external tool application via an LTI request message. It is, effectively, a Digital Resource that must use LTI for access."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -4292,13 +4693,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid273"
+    "@id" : "_:genid295"
   }, {
-    "@id" : "_:genid298"
+    "@id" : "_:genid320"
   }, {
-    "@id" : "_:genid303"
+    "@id" : "_:genid325"
   }, {
-    "@id" : "_:genid308"
+    "@id" : "_:genid330"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/MediaLocation",
@@ -4365,9 +4766,9 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   }, {
-    "@id" : "_:genid309"
+    "@id" : "_:genid331"
   }, {
-    "@id" : "_:genid314"
+    "@id" : "_:genid336"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Message",
@@ -4386,7 +4787,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   }, {
-    "@id" : "_:genid319"
+    "@id" : "_:genid341"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/MessageEvent",
@@ -4405,11 +4806,11 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid324"
+    "@id" : "_:genid346"
   }, {
-    "@id" : "_:genid333"
+    "@id" : "_:genid355"
   }, {
-    "@id" : "_:genid338"
+    "@id" : "_:genid360"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Metric",
@@ -4424,6 +4825,23 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Metric"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/MultiSelectResponse",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper MultiselectResponse represents a response to a MultiselectQuestion in which the respondent is permitted to choose one or more options from a pre-defined set of responses."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "MultiSelectResponse"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Response"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale",
@@ -4477,6 +4895,23 @@
     "@id" : "http://purl.imsglobal.org/caliper/Response"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/MultiselectQuestion",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper MultiselectQuestion represents a form of a closed-end question type with a pre-defined set of responses where a respondent can choose multiple items in the set."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "MultiselectQuestion"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Question"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/NavigationEvent",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -4493,15 +4928,15 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid343"
+    "@id" : "_:genid365"
   }, {
-    "@id" : "_:genid348"
+    "@id" : "_:genid370"
   }, {
-    "@id" : "_:genid353"
+    "@id" : "_:genid375"
   }, {
-    "@id" : "_:genid361"
+    "@id" : "_:genid383"
   }, {
-    "@id" : "_:genid369"
+    "@id" : "_:genid391"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/NumericScale",
@@ -4519,6 +4954,40 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Scale"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/OpenEndedQuestion",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper OpenEndedQuestion represents a question with no pre-defined response. Respondents can record their response in the form of qualitative feedback with no length limit imposed."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "OpenEndedQuestion"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Question"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/OpenEndedResponse",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper OpenEndedResponse represents a respondent's response to a OpenEndedQuestion."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "OpenEndedResponse"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Response"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Organization",
@@ -4557,13 +5026,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid370"
+    "@id" : "_:genid392"
   }, {
-    "@id" : "_:genid375"
+    "@id" : "_:genid397"
   }, {
-    "@id" : "_:genid383"
+    "@id" : "_:genid405"
   }, {
-    "@id" : "_:genid388"
+    "@id" : "_:genid410"
   } ],
   "http://www.w3.org/2002/07/owl#deprecated" : [ {
     "@type" : "http://www.w3.org/2001/XMLSchema#boolean",
@@ -4640,6 +5109,88 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/Questionnaire",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper Questionnaire represents a collection of QuestionnaireItem entities that is designed to elicit information from one or more respondents."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Questionnaire"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireEvent",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper QuestionnaireEvent models activities associated with respondents or raters starting and submitting a Questionnaire."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "QuestionnaireEvent"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Event"
+  }, {
+    "@id" : "_:genid415"
+  }, {
+    "@id" : "_:genid423"
+  }, {
+    "@id" : "_:genid428"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireItem",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper QuestionnaireItem represents a Question that is associated with a Questionnaire."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "QuestionnaireItem"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireItemEvent",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper QuestionnaireItemEvent models activities associated with respondents or raters starting, completing, or skipping a QuestionnaireItem."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "QuestionnaireItemEvent"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Event"
+  }, {
+    "@id" : "_:genid433"
+  }, {
+    "@id" : "_:genid442"
+  }, {
+    "@id" : "_:genid447"
+  }, {
+    "@id" : "_:genid452"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/Rating",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -4656,9 +5207,43 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   }, {
-    "@id" : "_:genid393"
+    "@id" : "_:genid453"
   }, {
-    "@id" : "_:genid398"
+    "@id" : "_:genid458"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/RatingScaleQuestion",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper RatingScaleQuestion represents a Question that employs a Scale."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "RatingScaleQuestion"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Question"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/RatingScaleResponse",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper RatingScaleResponse represents a respondent's response to a RatingScaleQuestion."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "RatingScaleResponse"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Response"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Reading",
@@ -4701,13 +5286,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid399"
+    "@id" : "_:genid459"
   }, {
-    "@id" : "_:genid408"
+    "@id" : "_:genid468"
   }, {
-    "@id" : "_:genid413"
+    "@id" : "_:genid473"
   }, {
-    "@id" : "_:genid418"
+    "@id" : "_:genid478"
   } ],
   "http://www.w3.org/2002/07/owl#deprecated" : [ {
     "@type" : "http://www.w3.org/2001/XMLSchema#boolean",
@@ -4743,13 +5328,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid419"
+    "@id" : "_:genid479"
   }, {
-    "@id" : "_:genid439"
+    "@id" : "_:genid499"
   }, {
-    "@id" : "_:genid444"
+    "@id" : "_:genid504"
   }, {
-    "@id" : "_:genid449"
+    "@id" : "_:genid509"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ResourceManagementProfile",
@@ -4865,11 +5450,11 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid450"
+    "@id" : "_:genid510"
   }, {
-    "@id" : "_:genid455"
+    "@id" : "_:genid515"
   }, {
-    "@id" : "_:genid460"
+    "@id" : "_:genid520"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/SearchProfile",
@@ -4951,7 +5536,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   }, {
-    "@id" : "_:genid461"
+    "@id" : "_:genid521"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/SessionEvent",
@@ -4970,15 +5555,15 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid466"
+    "@id" : "_:genid526"
   }, {
-    "@id" : "_:genid475"
+    "@id" : "_:genid535"
   }, {
-    "@id" : "_:genid483"
+    "@id" : "_:genid543"
   }, {
-    "@id" : "_:genid491"
+    "@id" : "_:genid551"
   }, {
-    "@id" : "_:genid499"
+    "@id" : "_:genid559"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/SessionProfile",
@@ -5041,6 +5626,88 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Status"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/Survey",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper Survey represents a research method for collecting data from a targeted group of respondents. The Survey provides a standardized process for gathering data that utilizes one or more Questionnaire entities."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Survey"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Collection"
+  }, {
+    "@id" : "_:genid560"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/SurveyEvent",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A SurveyEvent models activities associated with calls to participate in a Survey."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "SurveyEvent"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Event"
+  }, {
+    "@id" : "_:genid565"
+  }, {
+    "@id" : "_:genid573"
+  }, {
+    "@id" : "_:genid578"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitation",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper SurveyInvitation represents a survey invitation sent to raters."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "SurveyInvitation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitationEvent",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Caliper SurveyInvitationEvent models activities associated with calls to participate in a Survey."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "SurveyInvitationEvent"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Event"
+  }, {
+    "@id" : "_:genid583"
+  }, {
+    "@id" : "_:genid592"
+  }, {
+    "@id" : "_:genid597"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/SurveyProfile",
@@ -5107,9 +5774,9 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
   }, {
-    "@id" : "_:genid500"
+    "@id" : "_:genid602"
   }, {
-    "@id" : "_:genid505"
+    "@id" : "_:genid607"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ThreadEvent",
@@ -5128,11 +5795,11 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid510"
+    "@id" : "_:genid612"
   }, {
-    "@id" : "_:genid518"
+    "@id" : "_:genid620"
   }, {
-    "@id" : "_:genid523"
+    "@id" : "_:genid625"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ToolLaunchEvent",
@@ -5152,17 +5819,17 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid528"
+    "@id" : "_:genid630"
   }, {
-    "@id" : "_:genid536"
+    "@id" : "_:genid638"
   }, {
-    "@id" : "_:genid541"
+    "@id" : "_:genid643"
   }, {
-    "@id" : "_:genid546"
+    "@id" : "_:genid648"
   }, {
-    "@id" : "_:genid554"
+    "@id" : "_:genid656"
   }, {
-    "@id" : "_:genid555"
+    "@id" : "_:genid657"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ToolLaunchProfile",
@@ -5195,13 +5862,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid556"
+    "@id" : "_:genid658"
   }, {
-    "@id" : "_:genid561"
+    "@id" : "_:genid663"
   }, {
-    "@id" : "_:genid566"
+    "@id" : "_:genid668"
   }, {
-    "@id" : "_:genid571"
+    "@id" : "_:genid673"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ToolUseProfile",
@@ -5268,13 +5935,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid572"
+    "@id" : "_:genid674"
   }, {
-    "@id" : "_:genid577"
+    "@id" : "_:genid679"
   }, {
-    "@id" : "_:genid582"
+    "@id" : "_:genid684"
   }, {
-    "@id" : "_:genid587"
+    "@id" : "_:genid689"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/WebPage",
@@ -5348,6 +6015,20 @@
     "@value" : "Abandoned"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/Accepted",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Accepted action signals that an affirmative reply was given with regard to some Entity. Inverse of Declined."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Accepted"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/actions/Activated",
   "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -5374,6 +6055,20 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Added"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/Archived",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Put into an archive. The Archived action signals that a resource has been put into long-term storage. Inverse of Restored."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://wordnet-rdf.princeton.edu/wn31/201387292-v"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Archived"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/actions/Attached",
@@ -5571,6 +6266,20 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Deactivated"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/Declined",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Declined action signals that a negative reply or refusal was given with regard to some Entity. Inverse of Accepted."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Declined"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/actions/Deleted",
@@ -5795,6 +6504,20 @@
     "@value" : "JumpedTo"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/Launched",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Get going; give impetus to."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "href=\"http://wordnet-rdf.princeton.edu/wn31/01515196-v"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Launched"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/actions/Liked",
   "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -5944,6 +6667,34 @@
     "@value" : "http://wordnet-rdf.princeton.edu/wn31/202431018-v"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/OptedIn",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The OptedIn action signals that a Person agreed to participate in an activity or complete a task. Inverse of OptedOut."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "OptedIn"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/OptedOut",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The OptedOut action signals that a Person declined to participate in an activity or complete a task. Inverse of OptedIn."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "OptedOut"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/actions/Paused",
   "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -6091,6 +6842,9 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
+    "@value" : "Return to its original or usable and functioning condition. Inverse of Archived."
+  }, {
+    "@language" : "en",
     "@value" : "Return to its original or usable and functioning condition. The Restored action signals that an archived resource has been retrieved from long-term storage. Inverse of Archived."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
@@ -6130,6 +6884,20 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Retrieved"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/Returned",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Go or come back to place, condition, or activity where one has been before."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://wordnet-rdf.princeton.edu/wn31/01515196-v"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Returned"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/actions/Reviewed",
@@ -6186,6 +6954,20 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Searched"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/actions/Sent",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Sent action signals that some Entity was transmitted or transferred."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Sent"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/actions/Shared",
@@ -6597,6 +7379,23 @@
     "@id" : "http://www.w3.org/2001/XMLSchema#string"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/categories",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "An array of category items."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireItem"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "categories"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/category",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -6945,6 +7744,46 @@
     "@id" : "http://www.w3.org/2001/XMLSchema#dateTime"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/dateSent",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A date and time value expressed with millisecond precision that describes when the SurveyInvitation was sent."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "dateSent"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#dateTime"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/dateTimeSelected",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The date and time selected in response to the Question."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DateTimeResponse"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "dateTimeSelected"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#dateTime"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/dateToActivate",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -7052,7 +7891,7 @@
     "@value" : "A time interval that represents the total time required to complete an activity."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid23"
+    "@id" : "_:genid38"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -7115,7 +7954,7 @@
     "@value" : "A date and time value expressed with millisecond precision that describes when the activity was completed or terminated."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid28"
+    "@id" : "_:genid43"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -7191,7 +8030,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   }, {
-    "@id" : "_:genid588"
+    "@id" : "_:genid690"
   } ],
   "http://www.w3.org/2002/07/owl#deprecated" : [ {
     "@type" : "http://www.w3.org/2001/XMLSchema#boolean",
@@ -7344,7 +8183,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/host",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "Identifies the host of a SoftwareApplication. This property can be used to indicate the back-end service or domain hosting a front-end web application."
@@ -7370,7 +8209,7 @@
     "@value" : "The Event or Entity identifier.  For an Event, the id MUST be a UUID expressed as a URN using the form urn:uuid:<UUID> per RFC 4122.  For Entities a valid IRI MUST be specified. The IRI MUST be unique and persistent. The IRI SHOULD also be dereferenceable, i.e., capable of returning a representation of the resource.  An Entity MAY be provisioned with a URI employing the URN scheme in cases where a Linked Data friendly HTTP URI is either unavailable or inappropriate."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid33"
+    "@id" : "_:genid48"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -7404,7 +8243,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ipAddress",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "Indicates the IPv4 or IPv6 address of a SoftwareApplication. This property can be used to indicate the user agent (browser) running a front-end web application."
@@ -7487,7 +8326,7 @@
     "@value" : "The ordered list of values for each point on the Likert scale."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid14"
+    "@id" : "_:genid15"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "https://purl.imsglobal.org/caliper"
@@ -7605,6 +8444,29 @@
     "@id" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/maxDateTime",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A date and time value used to determine the maximum value allowed."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DateTimeQuestion"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "maxDateTime"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#dateTime"
+  } ],
+  "http://www.w3.org/2002/07/owl#propertyDisjointWith" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/minDateTime"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/maxLabel",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -7612,7 +8474,7 @@
     "@value" : "The label for the maximum value."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/NumericScale"
+    "@id" : "_:genid51"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "https://purl.imsglobal.org/caliper"
@@ -7675,7 +8537,7 @@
     "@value" : "A non-negative integer indicating the maximum score permitted."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid36"
+    "@id" : "_:genid54"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -8012,6 +8874,26 @@
     "@value" : "WordsRead"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/minDateTime",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A date and time value used to determine the minimum value allowed."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DateTimeQuestion"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "minDateTime"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#dateTime"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/minLabel",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -8019,7 +8901,7 @@
     "@value" : "The label for the minimum value."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/NumericScale"
+    "@id" : "_:genid57"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "https://purl.imsglobal.org/caliper"
@@ -8272,17 +9154,17 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "A integer value used to determine the amount of points on the LikertScale."
+    "@value" : "A integer value used to determine the amount of points on the  MultiselectQuestion."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid39"
+    "@id" : "http://purl.imsglobal.org/caliper/MultiselectQuestion"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "https://purl.imsglobal.org/caliper"
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
-    "@value" : "scalePoints"
+    "@value" : "points"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://www.w3.org/2001/XMLSchema#integer"
@@ -8335,7 +9217,7 @@
     "@value" : "The Question used for the Rating."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    "@id" : "_:genid19"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -8346,6 +9228,26 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Question"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/questionPosed",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A string value comprising the question posed."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Question"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "questionPosed"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#string"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/rated",
@@ -8375,7 +9277,7 @@
     "@value" : "The Person who provided the Rating."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    "@id" : "_:genid22"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "https://purl.imsglobal.org/caliper"
@@ -8492,10 +9394,10 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "The Scale used for the Rating."
+    "@value" : "The Scale associated with the Rating or RatingScaleQuestion."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    "@id" : "_:genid25"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "https://purl.imsglobal.org/caliper"
@@ -8506,6 +9408,26 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Scale"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/scalePoints",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A integer value used to determine the amount of points on the LikertScale."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "_:genid60"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "https://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "scalePoints"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#integer"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/scoreGiven",
@@ -8535,7 +9457,7 @@
     "@value" : "The Agent who scored or graded an Attempt."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid17"
+    "@id" : "_:genid28"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -8595,7 +9517,7 @@
     "@value" : "The Entity, typically a DigitalResource or  SoftwareApplication, that is the target of the search."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid20"
+    "@id" : "_:genid31"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -8675,7 +9597,7 @@
     "@value" : "An array of the values representing the rater's selected response."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Rating"
+    "@id" : "_:genid34"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "https://purl.imsglobal.org/caliper"
@@ -8725,6 +9647,26 @@
     "@id" : "http://www.w3.org/2001/XMLSchema#string"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/sentCount",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "An integer value used to determine the amount of times a SurveyInvitation was sent to the rater."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "sentCount"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#integer"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/session",
   "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -8772,7 +9714,7 @@
     "@value" : "A date and time value expressed with millisecond precision that describes when the activity commenced."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid42"
+    "@id" : "_:genid63"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -8865,6 +9807,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Organization"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/survey",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Survey that the invitation is for."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SurveyInvitation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "survey"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Survey"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/tags",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -8936,7 +9898,7 @@
     "@value" : "A string value corresponding to the Class name or label of an Event or Entity."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid47"
+    "@id" : "_:genid68"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -8970,7 +9932,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/userAgent",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "Describes the properties of the user agent hosting a SoftwareApplication. This field can be used to carry the user agent string reported by the browser running a front-end web application."
@@ -8996,7 +9958,7 @@
     "@value" : "A string value that represents the options selected."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid50"
+    "@id" : "_:genid71"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -9016,7 +9978,7 @@
     "@value" : "An ordered collection of one or more selected options."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid53"
+    "@id" : "_:genid75"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -9036,7 +9998,7 @@
     "@value" : "A string value that designates the current form or version of the resource."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "_:genid57"
+    "@id" : "_:genid79"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "http://purl.imsglobal.org/caliper"
@@ -9110,6 +10072,26 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://www.w3.org/2001/XMLSchema#string"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/weight",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A decimal value used to determine the weight of the QuestionnaireItem."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/QuestionnaireItem"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "weight"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#decimal"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/withAgents",

--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -3671,6 +3671,20 @@
     "@id" : "_:genid96"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/AnnotationProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Annotation Profile models activities related to the annotation of a DigitalResource."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "AnnotationProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/Assessment",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -3761,6 +3775,20 @@
     "@id" : "_:genid157"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/AssessmentProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Assessment Profile models assessment-related activities including interactions with individual assessment items."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "AssessmentProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://purl.org/dc/terms/isReplacedBy" : [ {
@@ -3806,6 +3834,20 @@
     "@id" : "_:genid180"
   }, {
     "@id" : "_:genid181"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/AssignableProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Assignable Profile models activities associated with the assignment of digital content to a learner for completion according to specific criteria."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "AssignableProfile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Attempt",
@@ -4081,6 +4123,20 @@
     "@id" : "_:genid230"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/FeedbackProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Feedback Profile models a Person providing informal feedback on a Entity, typically a piece of student work."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "FeedbackProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/FillinBlankResponse",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -4143,6 +4199,20 @@
     "@id" : "_:genid249"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/ForumProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Forum Profile models learners and others participating in online discussion forums. Forums typically encompass one or more threads or topics to which members can subscribe, post messages and reply to other messages if a threaded discussion is permitted."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "ForumProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/Frame",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -4158,6 +4228,20 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/GeneralProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Caliper General Profile provides a generic Event for describing learning or supporting activities that have yet to be modeled by Caliper."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "GeneralProfile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/GradeEvent",
@@ -4183,6 +4267,20 @@
     "@id" : "_:genid267"
   }, {
     "@id" : "_:genid272"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/GradingProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Grading Profile models grading activities performed by an Agent, typically a Person or a SoftwareApplication."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "GradingProfile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Group",
@@ -4389,6 +4487,20 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/MediaProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Media Profile models interactions between learners and rich content such as audio, images and video."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "MediaProfile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Membership",
@@ -4646,6 +4758,9 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/Profile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/Query",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -4737,6 +4852,19 @@
     "@value" : "true"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/ReadingProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@language" : "en",
+    "@value" : "The Reading Profile models activities associated with navigating to and viewing digital textual content."
+  }, {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "ReadingProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/ResourceManagementEvent",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -4760,6 +4888,20 @@
     "@id" : "_:genid440"
   }, {
     "@id" : "_:genid445"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/ResourceManagementProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Resource Management Profile models a Person managing a DigitalResource."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "ResourceManagementProfile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Response",
@@ -4868,6 +5010,20 @@
     "@id" : "_:genid456"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/SearchProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Search Profile models an actor, typically a learner, querying a resource for information."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "SearchProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/SearchResponse",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -4963,6 +5119,20 @@
     "@id" : "_:genid495"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/SessionProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Session Profile models the creation and subsequent termination of a user session established by a Person interacting with a SoftwareApplication."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "SessionProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/SharedAnnotation",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -5009,6 +5179,20 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Status"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/SurveyProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Survey Profile provides a vocabulary for describing events associated with a respondent's participation in online surveys."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "SurveyProfile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/TagAnnotation",
@@ -5119,6 +5303,20 @@
     "@id" : "_:genid551"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/ToolLaunchProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Tool Launch Profile is intended to capture the utilization of learning tools from a centralized location, such as an LTI Tool Platform (often an LMS)."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "ToolLaunchProfile"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/ToolUseEvent",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -5142,6 +5340,20 @@
     "@id" : "_:genid562"
   }, {
     "@id" : "_:genid567"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/ToolUseProfile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Profile" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The Tool Use Profile models an intended interaction between a user and a tool. In other words, when a Person utilizes a SoftwareApplication in a manner that the application determines to be its intended use for learning, an application that implements the Tool Use Profile can emit a ToolUseEvent indicating such usage."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "ToolUseProfile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/TrueFalseResponse",
@@ -8212,6 +8424,26 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://www.w3.org/2001/XMLSchema#integer"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/profile",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Named profile that governs the rules of interpretation for an Event. The range of profile values is limited to the set of profiles described by the Caliper specification and any profile extension specifications extending the Caliper specification."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Event"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "profile"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Profile"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/query",

--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -6543,6 +6543,26 @@
     "@id" : "http://www.w3.org/2001/XMLSchema#string"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/client",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The SoftwareApplication that is hosting a Session."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Session"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "client"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/comment",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {

--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -1751,7 +1751,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid434"
+      "@id" : "_:genid438"
     }, {
       "@id" : "_:genid421"
     } ]
@@ -1786,13 +1786,9 @@
     "@list" : [ {
       "@id" : "http://purl.imsglobal.org/actions/Archived"
     }, {
-      "@id" : "http://purl.imsglobal.org/actions/Copied"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Published"
-    }, {
       "@id" : "http://purl.imsglobal.org/actions/Restored"
     }, {
-      "@id" : "http://purl.imsglobal.org/actions/Unpublished"
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Copied"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Created"
     }, {
@@ -1800,13 +1796,25 @@
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Described"
     }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Downloaded"
+    }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Modified"
     }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Printed"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Published"
+    }, {
       "@id" : "http://purl.imsglobal.org/caliper/actions/Retrieved"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Saved"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Unpublished"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/actions/Uploaded"
     } ]
   } ]
 }, {
-  "@id" : "_:genid434",
+  "@id" : "_:genid438",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -1815,17 +1823,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid435",
+  "@id" : "_:genid439",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid439"
+      "@id" : "_:genid443"
     }, {
-      "@id" : "_:genid437"
+      "@id" : "_:genid441"
     } ]
   } ]
 }, {
-  "@id" : "_:genid437",
+  "@id" : "_:genid441",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -1834,7 +1842,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid439",
+  "@id" : "_:genid443",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -1843,17 +1851,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid440",
+  "@id" : "_:genid444",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid444"
+      "@id" : "_:genid448"
     }, {
-      "@id" : "_:genid442"
+      "@id" : "_:genid446"
     } ]
   } ]
 }, {
-  "@id" : "_:genid442",
+  "@id" : "_:genid446",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
@@ -1862,7 +1870,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid444",
+  "@id" : "_:genid448",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -1871,7 +1879,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid445",
+  "@id" : "_:genid449",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -1880,17 +1888,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid446",
+  "@id" : "_:genid450",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid450"
+      "@id" : "_:genid454"
     }, {
-      "@id" : "_:genid448"
+      "@id" : "_:genid452"
     } ]
   } ]
 }, {
-  "@id" : "_:genid448",
+  "@id" : "_:genid452",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#hasValue" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actions/Searched"
@@ -1899,7 +1907,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ]
 }, {
-  "@id" : "_:genid450",
+  "@id" : "_:genid454",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -1908,17 +1916,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid451",
+  "@id" : "_:genid455",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid455"
+      "@id" : "_:genid459"
     }, {
-      "@id" : "_:genid453"
+      "@id" : "_:genid457"
     } ]
   } ]
 }, {
-  "@id" : "_:genid453",
+  "@id" : "_:genid457",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -1927,7 +1935,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid455",
+  "@id" : "_:genid459",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -1936,7 +1944,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid456",
+  "@id" : "_:genid460",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -1945,17 +1953,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
   } ]
 }, {
-  "@id" : "_:genid457",
+  "@id" : "_:genid461",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid461"
+      "@id" : "_:genid465"
     }, {
-      "@id" : "_:genid459"
+      "@id" : "_:genid463"
     } ]
   } ]
 }, {
-  "@id" : "_:genid459",
+  "@id" : "_:genid463",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -1964,7 +1972,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/user"
   } ]
 }, {
-  "@id" : "_:genid461",
+  "@id" : "_:genid465",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/user"
@@ -1973,26 +1981,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid462",
+  "@id" : "_:genid466",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid470"
+      "@id" : "_:genid474"
     }, {
-      "@id" : "_:genid464"
+      "@id" : "_:genid468"
     } ]
   } ]
 }, {
-  "@id" : "_:genid464",
+  "@id" : "_:genid468",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid465"
+    "@id" : "_:genid469"
   } ]
 }, {
-  "@id" : "_:genid465",
+  "@id" : "_:genid469",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -2014,7 +2022,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid470",
+  "@id" : "_:genid474",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -2023,26 +2031,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid471",
+  "@id" : "_:genid475",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid478"
+      "@id" : "_:genid482"
     }, {
-      "@id" : "_:genid473"
+      "@id" : "_:genid477"
     } ]
   } ]
 }, {
-  "@id" : "_:genid473",
+  "@id" : "_:genid477",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid474"
+    "@id" : "_:genid478"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid474",
+  "@id" : "_:genid478",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -2052,7 +2060,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid478",
+  "@id" : "_:genid482",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -2061,26 +2069,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid479",
+  "@id" : "_:genid483",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid486"
+      "@id" : "_:genid490"
     }, {
-      "@id" : "_:genid481"
+      "@id" : "_:genid485"
     } ]
   } ]
 }, {
-  "@id" : "_:genid481",
+  "@id" : "_:genid485",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid482"
+    "@id" : "_:genid486"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid482",
+  "@id" : "_:genid486",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -2090,7 +2098,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid486",
+  "@id" : "_:genid490",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -2099,26 +2107,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid487",
+  "@id" : "_:genid491",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid494"
+      "@id" : "_:genid498"
     }, {
-      "@id" : "_:genid489"
+      "@id" : "_:genid493"
     } ]
   } ]
 }, {
-  "@id" : "_:genid489",
+  "@id" : "_:genid493",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid490"
+    "@id" : "_:genid494"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/referrer"
   } ]
 }, {
-  "@id" : "_:genid490",
+  "@id" : "_:genid494",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -2128,7 +2136,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid494",
+  "@id" : "_:genid498",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/referrer"
@@ -2137,32 +2145,13 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid495",
+  "@id" : "_:genid499",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
-  } ]
-}, {
-  "@id" : "_:genid496",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid500"
-    }, {
-      "@id" : "_:genid498"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid498",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Forum"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
   } ]
 }, {
   "@id" : "_:genid5",
@@ -2186,6 +2175,25 @@
   } ]
 }, {
   "@id" : "_:genid500",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid504"
+    }, {
+      "@id" : "_:genid502"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid502",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Forum"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
+  } ]
+}, {
+  "@id" : "_:genid504",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
@@ -2194,17 +2202,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid501",
+  "@id" : "_:genid505",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid505"
+      "@id" : "_:genid509"
     }, {
-      "@id" : "_:genid503"
+      "@id" : "_:genid507"
     } ]
   } ]
 }, {
-  "@id" : "_:genid503",
+  "@id" : "_:genid507",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Message"
@@ -2213,7 +2221,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/items"
   } ]
 }, {
-  "@id" : "_:genid505",
+  "@id" : "_:genid509",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/items"
@@ -2222,26 +2230,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid506",
+  "@id" : "_:genid510",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid513"
+      "@id" : "_:genid517"
     }, {
-      "@id" : "_:genid508"
+      "@id" : "_:genid512"
     } ]
   } ]
 }, {
-  "@id" : "_:genid508",
+  "@id" : "_:genid512",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid509"
+    "@id" : "_:genid513"
   } ]
 }, {
-  "@id" : "_:genid509",
+  "@id" : "_:genid513",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#oneOf" : [ {
     "@list" : [ {
@@ -2251,7 +2259,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid513",
+  "@id" : "_:genid517",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -2260,17 +2268,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid514",
+  "@id" : "_:genid518",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid518"
+      "@id" : "_:genid522"
     }, {
-      "@id" : "_:genid516"
+      "@id" : "_:genid520"
     } ]
   } ]
 }, {
-  "@id" : "_:genid516",
+  "@id" : "_:genid520",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -2279,7 +2287,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid518",
+  "@id" : "_:genid522",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -2288,17 +2296,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid519",
+  "@id" : "_:genid523",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid523"
+      "@id" : "_:genid527"
     }, {
-      "@id" : "_:genid521"
+      "@id" : "_:genid525"
     } ]
   } ]
 }, {
-  "@id" : "_:genid521",
+  "@id" : "_:genid525",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Thread"
@@ -2307,7 +2315,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid523",
+  "@id" : "_:genid527",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -2316,32 +2324,13 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid524",
+  "@id" : "_:genid528",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid531"
+      "@id" : "_:genid535"
     }, {
-      "@id" : "_:genid526"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid526",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/action"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "_:genid527"
-  } ]
-}, {
-  "@id" : "_:genid527",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#oneOf" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/actions/Launched"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Returned"
+      "@id" : "_:genid530"
     } ]
   } ]
 }, {
@@ -2357,7 +2346,26 @@
     } ]
   } ]
 }, {
+  "@id" : "_:genid530",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/action"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "_:genid531"
+  } ]
+}, {
   "@id" : "_:genid531",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#oneOf" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/actions/Launched"
+    }, {
+      "@id" : "http://purl.imsglobal.org/actions/Returned"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid535",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -2366,17 +2374,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid532",
+  "@id" : "_:genid536",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid536"
+      "@id" : "_:genid540"
     }, {
-      "@id" : "_:genid534"
+      "@id" : "_:genid538"
     } ]
   } ]
 }, {
-  "@id" : "_:genid534",
+  "@id" : "_:genid538",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -2385,7 +2393,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid536",
+  "@id" : "_:genid540",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -2394,17 +2402,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid537",
+  "@id" : "_:genid541",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid541"
+      "@id" : "_:genid545"
     }, {
-      "@id" : "_:genid539"
+      "@id" : "_:genid543"
     } ]
   } ]
 }, {
-  "@id" : "_:genid539",
+  "@id" : "_:genid543",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
@@ -2413,7 +2421,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid541",
+  "@id" : "_:genid545",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -2422,26 +2430,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid542",
+  "@id" : "_:genid546",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid549"
+      "@id" : "_:genid553"
     }, {
-      "@id" : "_:genid544"
+      "@id" : "_:genid548"
     } ]
   } ]
 }, {
-  "@id" : "_:genid544",
+  "@id" : "_:genid548",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "_:genid545"
+    "@id" : "_:genid549"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
   } ]
 }, {
-  "@id" : "_:genid545",
+  "@id" : "_:genid549",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#unionOf" : [ {
     "@list" : [ {
@@ -2451,7 +2459,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid549",
+  "@id" : "_:genid553",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
@@ -2460,7 +2468,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid550",
+  "@id" : "_:genid554",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/generated"
@@ -2469,7 +2477,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
-  "@id" : "_:genid551",
+  "@id" : "_:genid555",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/LtiSession"
@@ -2478,17 +2486,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/federatedSession"
   } ]
 }, {
-  "@id" : "_:genid552",
+  "@id" : "_:genid556",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid556"
+      "@id" : "_:genid560"
     }, {
-      "@id" : "_:genid554"
+      "@id" : "_:genid558"
     } ]
   } ]
 }, {
-  "@id" : "_:genid554",
+  "@id" : "_:genid558",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#hasValue" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actions/Used"
@@ -2497,7 +2505,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ]
 }, {
-  "@id" : "_:genid556",
+  "@id" : "_:genid560",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -2506,17 +2514,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid557",
+  "@id" : "_:genid561",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid561"
+      "@id" : "_:genid565"
     }, {
-      "@id" : "_:genid559"
+      "@id" : "_:genid563"
     } ]
   } ]
 }, {
-  "@id" : "_:genid559",
+  "@id" : "_:genid563",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -2525,7 +2533,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid561",
+  "@id" : "_:genid565",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -2534,51 +2542,23 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid562",
+  "@id" : "_:genid566",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid566"
+      "@id" : "_:genid570"
     }, {
-      "@id" : "_:genid564"
+      "@id" : "_:genid568"
     } ]
   } ]
 }, {
-  "@id" : "_:genid564",
+  "@id" : "_:genid568",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
   } ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ]
-}, {
-  "@id" : "_:genid566",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/object"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Agent"
-  } ]
-}, {
-  "@id" : "_:genid567",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/target"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
-  } ]
-}, {
-  "@id" : "_:genid568",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid572"
-    }, {
-      "@id" : "_:genid570"
-    } ]
   } ]
 }, {
   "@id" : "_:genid57",
@@ -2593,6 +2573,34 @@
 }, {
   "@id" : "_:genid570",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/object"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid571",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/target"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ]
+}, {
+  "@id" : "_:genid572",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid576"
+    }, {
+      "@id" : "_:genid574"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid574",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#hasValue" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actions/Viewed"
   } ],
@@ -2600,7 +2608,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/action"
   } ]
 }, {
-  "@id" : "_:genid572",
+  "@id" : "_:genid576",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/action"
@@ -2609,17 +2617,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Action"
   } ]
 }, {
-  "@id" : "_:genid573",
+  "@id" : "_:genid577",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid577"
+      "@id" : "_:genid581"
     }, {
-      "@id" : "_:genid575"
+      "@id" : "_:genid579"
     } ]
   } ]
 }, {
-  "@id" : "_:genid575",
+  "@id" : "_:genid579",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -2628,7 +2636,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/actor"
   } ]
 }, {
-  "@id" : "_:genid577",
+  "@id" : "_:genid581",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/actor"
@@ -2637,17 +2645,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
   } ]
 }, {
-  "@id" : "_:genid578",
+  "@id" : "_:genid582",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid582"
+      "@id" : "_:genid586"
     }, {
-      "@id" : "_:genid580"
+      "@id" : "_:genid584"
     } ]
   } ]
 }, {
-  "@id" : "_:genid580",
+  "@id" : "_:genid584",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
@@ -2656,7 +2664,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/object"
   } ]
 }, {
-  "@id" : "_:genid582",
+  "@id" : "_:genid586",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/object"
@@ -2665,7 +2673,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid583",
+  "@id" : "_:genid587",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/target"
@@ -2674,17 +2682,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Frame"
   } ]
 }, {
-  "@id" : "_:genid584",
+  "@id" : "_:genid588",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
     "@list" : [ {
-      "@id" : "_:genid588"
+      "@id" : "_:genid592"
     }, {
-      "@id" : "_:genid586"
+      "@id" : "_:genid590"
     } ]
   } ]
 }, {
-  "@id" : "_:genid586",
+  "@id" : "_:genid590",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/epubChapter"
@@ -2693,7 +2701,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
   } ]
 }, {
-  "@id" : "_:genid588",
+  "@id" : "_:genid592",
   "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
   "http://www.w3.org/2002/07/owl#onProperty" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/isPartOf"
@@ -2702,7 +2710,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid589",
+  "@id" : "_:genid593",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2722,7 +2730,17 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid597",
+  "@id" : "_:genid60",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid64"
+    }, {
+      "@id" : "_:genid62"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid601",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2762,17 +2780,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid60",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid64"
-    }, {
-      "@id" : "_:genid62"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid615",
+  "@id" : "_:genid619",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2819,7 +2827,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/items"
   } ]
 }, {
-  "@id" : "_:genid632",
+  "@id" : "_:genid636",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2860,7 +2868,17 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid646",
+  "@id" : "_:genid65",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid69"
+    }, {
+      "@id" : "_:genid67"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid650",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2890,17 +2908,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid65",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid69"
-    }, {
-      "@id" : "_:genid67"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid659",
+  "@id" : "_:genid663",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2953,7 +2961,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/annotated"
   } ]
 }, {
-  "@id" : "_:genid679",
+  "@id" : "_:genid683",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -2992,7 +3000,7 @@
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ]
 }, {
-  "@id" : "_:genid692",
+  "@id" : "_:genid696",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3028,7 +3036,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid703",
+  "@id" : "_:genid707",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3040,7 +3048,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid707",
+  "@id" : "_:genid711",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3054,7 +3062,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid712",
+  "@id" : "_:genid716",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3067,18 +3075,6 @@
       "@id" : "http://purl.imsglobal.org/caliper/SelectTextResponse"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/TrueFalseResponse"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid718",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
-  "http://www.w3.org/2002/07/owl#members" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/NumericScale"
     } ]
   } ]
 }, {
@@ -3095,6 +3091,18 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/LikertScale"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MultiSelectScale"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/NumericScale"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid726",
+  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
+  "http://www.w3.org/2002/07/owl#members" : [ {
+    "@list" : [ {
       "@id" : "http://purl.imsglobal.org/caliper/Organization"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/Person"
@@ -3103,7 +3111,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid726",
+  "@id" : "_:genid730",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3125,167 +3133,13 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid735",
+  "@id" : "_:genid739",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
   "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
     "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/actions/Archived"
+      "@id" : "http://purl.imsglobal.org/caliper/lti/LtiDeepLinkingRequest"
     }, {
-      "@id" : "http://purl.imsglobal.org/actions/Copied"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Launched"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Published"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Restored"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Returned"
-    }, {
-      "@id" : "http://purl.imsglobal.org/actions/Unpublished"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Abandoned"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Activated"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Added"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Attached"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Bookmarked"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/ChangedResolution"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/ChangedSize"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/ChangedSpeed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/ChangedVolume"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Classified"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/ClosedPopout"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Commented"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Completed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Copied"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Created"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Deactivated"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Deleted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Described"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/DisabledClosedCaptioning"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Disliked"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Downloaded"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/EnabledClosedCaptioning"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Ended"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/EnteredFullScreen"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/ExitedFullScreen"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/ForwardedTo"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Graded"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Hid"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Highlighted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Identified"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/JumpedTo"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Liked"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Linked"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/LoggedIn"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/LoggedOut"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/MarkedAsRead"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/MarkedAsUnread"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Modified"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Muted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/NavigatedTo"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/OpenedPopout"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Paused"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Posted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Printed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Published"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Questioned"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Ranked"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Recommended"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Removed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Reset"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Restarted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Restored"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Resumed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Retrieved"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Reviewed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Rewound"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Saved"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Searched"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Shared"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Showed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Skipped"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Started"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Submitted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Subscribed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Tagged"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/TimedOut"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Unmuted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Unpublished"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Unsubscribed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Uploaded"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Used"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/actions/Viewed"
+      "@id" : "http://purl.imsglobal.org/caliper/lti/LtiResourceLinkRequest"
     } ]
   } ]
 }, {
@@ -3296,6 +3150,28 @@
   } ],
   "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "_:genid742",
+  "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
+  "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/AssessmentsPassed"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/AssessmentsSubmitted"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/MinutesOnTask"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/SkillsMastered"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/StandardsMastered"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/UnitsCompleted"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/UnitsPassed"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/metrics/WordsRead"
+    } ]
   } ]
 }, {
   "@id" : "_:genid75",
@@ -3338,38 +3214,6 @@
       "@id" : "http://purl.imsglobal.org/caliper/Entity"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/Event"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid815",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
-  "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/lti/LtiDeepLinkingRequest"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/lti/LtiResourceLinkRequest"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid818",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
-  "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
-    "@list" : [ {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/AssessmentsPassed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/AssessmentsSubmitted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/MinutesOnTask"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/SkillsMastered"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/StandardsMastered"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/UnitsCompleted"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/UnitsPassed"
-    }, {
-      "@id" : "http://purl.imsglobal.org/caliper/metrics/WordsRead"
     } ]
   } ]
 }, {
@@ -3480,20 +3324,6 @@
     "@value" : "Archived"
   } ]
 }, {
-  "@id" : "http://purl.imsglobal.org/actions/Copied",
-  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "Make a replica of."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "http://wordnet-rdf.princeton.edu/wn31/201697776-v"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "Copied"
-  } ]
-}, {
   "@id" : "http://purl.imsglobal.org/actions/Launched",
   "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.imsglobal.org/caliper/Action" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -3548,20 +3378,6 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Returned"
-  } ]
-}, {
-  "@id" : "http://purl.imsglobal.org/actions/Unpublished",
-  "@type" : [ "http://www.w3.org/2002/07/owl#NamedIndividual" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "Remove from public distribution or sale. Inverse of Published."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "http://wordnet-rdf.princeton.edu/wn31/200969657-v"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "Unpublished"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/",
@@ -4929,11 +4745,11 @@
   }, {
     "@id" : "_:genid419"
   }, {
-    "@id" : "_:genid435"
+    "@id" : "_:genid439"
   }, {
-    "@id" : "_:genid440"
+    "@id" : "_:genid444"
   }, {
-    "@id" : "_:genid445"
+    "@id" : "_:genid449"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ResourceManagementProfile",
@@ -5049,11 +4865,11 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid446"
+    "@id" : "_:genid450"
   }, {
-    "@id" : "_:genid451"
+    "@id" : "_:genid455"
   }, {
-    "@id" : "_:genid456"
+    "@id" : "_:genid460"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/SearchProfile",
@@ -5135,7 +4951,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   }, {
-    "@id" : "_:genid457"
+    "@id" : "_:genid461"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/SessionEvent",
@@ -5154,15 +4970,15 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid462"
+    "@id" : "_:genid466"
   }, {
-    "@id" : "_:genid471"
+    "@id" : "_:genid475"
   }, {
-    "@id" : "_:genid479"
+    "@id" : "_:genid483"
   }, {
-    "@id" : "_:genid487"
+    "@id" : "_:genid491"
   }, {
-    "@id" : "_:genid495"
+    "@id" : "_:genid499"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/SessionProfile",
@@ -5291,9 +5107,9 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
   }, {
-    "@id" : "_:genid496"
+    "@id" : "_:genid500"
   }, {
-    "@id" : "_:genid501"
+    "@id" : "_:genid505"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ThreadEvent",
@@ -5312,11 +5128,11 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid506"
+    "@id" : "_:genid510"
   }, {
-    "@id" : "_:genid514"
+    "@id" : "_:genid518"
   }, {
-    "@id" : "_:genid519"
+    "@id" : "_:genid523"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ToolLaunchEvent",
@@ -5336,17 +5152,17 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid524"
+    "@id" : "_:genid528"
   }, {
-    "@id" : "_:genid532"
+    "@id" : "_:genid536"
   }, {
-    "@id" : "_:genid537"
+    "@id" : "_:genid541"
   }, {
-    "@id" : "_:genid542"
+    "@id" : "_:genid546"
   }, {
-    "@id" : "_:genid550"
+    "@id" : "_:genid554"
   }, {
-    "@id" : "_:genid551"
+    "@id" : "_:genid555"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ToolLaunchProfile",
@@ -5379,13 +5195,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid552"
+    "@id" : "_:genid556"
   }, {
-    "@id" : "_:genid557"
+    "@id" : "_:genid561"
   }, {
-    "@id" : "_:genid562"
+    "@id" : "_:genid566"
   }, {
-    "@id" : "_:genid567"
+    "@id" : "_:genid571"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/ToolUseProfile",
@@ -5452,13 +5268,13 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   }, {
-    "@id" : "_:genid568"
+    "@id" : "_:genid572"
   }, {
-    "@id" : "_:genid573"
+    "@id" : "_:genid577"
   }, {
-    "@id" : "_:genid578"
+    "@id" : "_:genid582"
   }, {
-    "@id" : "_:genid583"
+    "@id" : "_:genid587"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/WebPage",
@@ -7375,7 +7191,7 @@
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   }, {
-    "@id" : "_:genid584"
+    "@id" : "_:genid588"
   } ],
   "http://www.w3.org/2002/07/owl#deprecated" : [ {
     "@type" : "http://www.w3.org/2001/XMLSchema#boolean",

--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -2961,6 +2961,45 @@
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/Chapter"
     }, {
+      "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Document"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Frame"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/LtiLink"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MediaLocation"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/MediaObject"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Message"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Page"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Question"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/WebPage"
+    } ]
+  } ]
+}, {
+  "@id" : "_:genid69",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/annotated"
+  } ],
+  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "_:genid692",
+  "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
+  "http://www.w3.org/2002/07/owl#members" : [ {
+    "@list" : [ {
+      "@id" : "http://purl.imsglobal.org/caliper/AssignableDigitalResource"
+    }, {
+      "@id" : "http://purl.imsglobal.org/caliper/Chapter"
+    }, {
       "@id" : "http://purl.imsglobal.org/caliper/Document"
     }, {
       "@id" : "http://purl.imsglobal.org/caliper/Frame"
@@ -2979,16 +3018,17 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid69",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/annotated"
-  } ],
-  "http://www.w3.org/2002/07/owl#someValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  "@id" : "_:genid70",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
+    "@list" : [ {
+      "@id" : "_:genid74"
+    }, {
+      "@id" : "_:genid72"
+    } ]
   } ]
 }, {
-  "@id" : "_:genid690",
+  "@id" : "_:genid703",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3000,7 +3040,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid694",
+  "@id" : "_:genid707",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3014,7 +3054,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid699",
+  "@id" : "_:genid712",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3030,17 +3070,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid70",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2002/07/owl#intersectionOf" : [ {
-    "@list" : [ {
-      "@id" : "_:genid74"
-    }, {
-      "@id" : "_:genid72"
-    } ]
-  } ]
-}, {
-  "@id" : "_:genid705",
+  "@id" : "_:genid718",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3052,7 +3082,16 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid709",
+  "@id" : "_:genid72",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
+  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Person"
+  } ],
+  "http://www.w3.org/2002/07/owl#onProperty" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/annotator"
+  } ]
+}, {
+  "@id" : "_:genid722",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3064,7 +3103,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid713",
+  "@id" : "_:genid726",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDisjointClasses" ],
   "http://www.w3.org/2002/07/owl#members" : [ {
     "@list" : [ {
@@ -3086,16 +3125,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid72",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Restriction" ],
-  "http://www.w3.org/2002/07/owl#allValuesFrom" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Person"
-  } ],
-  "http://www.w3.org/2002/07/owl#onProperty" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/annotator"
-  } ]
-}, {
-  "@id" : "_:genid722",
+  "@id" : "_:genid735",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
   "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
     "@list" : [ {
@@ -3311,7 +3341,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid802",
+  "@id" : "_:genid815",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
   "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
     "@list" : [ {
@@ -3321,7 +3351,7 @@
     } ]
   } ]
 }, {
-  "@id" : "_:genid805",
+  "@id" : "_:genid818",
   "@type" : [ "http://www.w3.org/2002/07/owl#AllDifferent" ],
   "http://www.w3.org/2002/07/owl#distinctMembers" : [ {
     "@list" : [ {
@@ -4776,6 +4806,22 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/Question",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A Question is a generic type that represents an interrogative expression designed to elicit information from a respondent, featuring either a closed-end format with a set of predefined responses or an open-ended format."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Question"
+  }, {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Rating",
@@ -8467,24 +8513,23 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/question",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "A string value comprising the question posed to be scaled."
+    "@value" : "The Question used for the Rating."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Scale"
+    "@id" : "http://purl.imsglobal.org/caliper/Rating"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@language" : "en",
-    "@value" : "https://purl.imsglobal.org/caliper"
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "question"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
-    "@id" : "http://www.w3.org/2001/XMLSchema#string"
+    "@id" : "http://purl.imsglobal.org/caliper/Question"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/rated",
@@ -8812,6 +8857,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "An array of the values representing the rater's selected response."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Rating"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
     "@value" : "https://purl.imsglobal.org/caliper"

--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -7249,6 +7249,26 @@
     "@id" : "http://purl.imsglobal.org/caliper/Organization"
   } ]
 }, {
+  "@id" : "http://purl.imsglobal.org/caliper/host",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Identifies the host of a SoftwareApplication. This property can be used to indicate the back-end service or domain hosting a front-end web application."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "host"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#string"
+  } ]
+}, {
   "@id" : "http://purl.imsglobal.org/caliper/id",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
@@ -7287,6 +7307,26 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://www.w3.org/2001/XMLSchema#long"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/ipAddress",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Indicates the IPv4 or IPv6 address of a SoftwareApplication. This property can be used to indicate the user agent (browser) running a front-end web application."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "ipAddress"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#string"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/isPartOf",
@@ -8831,6 +8871,26 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Agent"
+  } ]
+}, {
+  "@id" : "http://purl.imsglobal.org/caliper/userAgent",
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Describes the properties of the user agent hosting a SoftwareApplication. This field can be used to carry the user agent string reported by the browser running a front-end web application."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "userAgent"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://www.w3.org/2001/XMLSchema#string"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/value",

--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -8707,26 +8707,6 @@
     "@id" : "http://purl.imsglobal.org/caliper/SoftwareApplication"
   } ]
 }, {
-  "@id" : "http://purl.imsglobal.org/caliper/searchResults",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "An ordered collection of entities, typically of type DigitalResource that constitute the results of the search."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/SearchResponse"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "http://purl.imsglobal.org/caliper"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "searchResults"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Entity"
-  } ]
-}, {
   "@id" : "http://purl.imsglobal.org/caliper/searchResultsItemCount",
   "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {

--- a/ontology/caliper-jsonld.owl
+++ b/ontology/caliper-jsonld.owl
@@ -7999,7 +7999,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/metric",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "The standard of measurement associated with the progress value."
@@ -8014,8 +8014,8 @@
     "@language" : "en",
     "@value" : "metric"
   } ],
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://www.w3.org/2002/07/owl#topDataProperty"
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Metric"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/metricValue",

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -715,19 +715,6 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
-    <!-- http://purl.imsglobal.org/caliper/searchResults -->
-
-    <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/searchResults">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SearchResponse"/>
-        <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
-        <rdfs:comment xml:lang="en">An ordered collection of entities, typically of type DigitalResource that constitute the results of the search.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">searchResults</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
     <!-- http://purl.imsglobal.org/caliper/searchTarget -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/searchTarget">

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -511,6 +511,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/metric -->
+
+    <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/metric">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AggregateMeasure"/>
+        <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Metric"/>
+        <rdfs:comment xml:lang="en">The standard of measurement associated with the progress value.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">metric</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/navigatedFrom -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/navigatedFrom">
@@ -1387,18 +1400,6 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A string value drawn from the list of IANA approved media types and subtypes that identifies the file format of a resource.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">mediaType</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://purl.imsglobal.org/caliper/metric -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/metric">
-        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AggregateMeasure"/>
-        <rdfs:comment xml:lang="en">The standard of measurement associated with the progress value.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">metric</rdfs:label>
     </owl:DatatypeProperty>
     
 

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -227,6 +227,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/client -->
+
+    <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/client">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Session"/>
+        <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
+        <rdfs:comment xml:lang="en">The SoftwareApplication that is hosting a Session.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">client</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/commentedOn -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/commentedOn">

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -591,6 +591,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/question -->
+
+    <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/question">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Rating"/>
+        <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Question"/>
+        <rdfs:comment xml:lang="en">The Question used for the Rating.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">question</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/rated -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/rated">
@@ -751,6 +764,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <!-- http://purl.imsglobal.org/caliper/selections -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/selections">
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Rating"/>
         <rdfs:comment xml:lang="en">An array of the values representing the rater&apos;s selected response.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">selections</rdfs:label>
@@ -1539,19 +1553,6 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A integer value used to determine the amount of points on the LikertScale.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">scalePoints</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://purl.imsglobal.org/caliper/question -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/question">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Scale"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:comment xml:lang="en">A string value comprising the question posed to be scaled.</rdfs:comment>
-        <rdfs:isDefinedBy xml:lang="en">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">question</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -3416,6 +3417,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A Caliper Query models search criteria created by an actor that targets a searchable resource.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Query</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/Question -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Question">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
+        <rdfs:comment xml:lang="en">A Question is a generic type that represents an interrogative expression designed to elicit information from a respondent, featuring either a closed-end format with a set of predefined responses or an open-ended format.</rdfs:comment>
+        <rdfs:label xml:lang="en">Question</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:label>
     </owl:Class>
     
 
@@ -6307,6 +6319,23 @@ The Caliper ontology provides a machine-readable document that defines the conce
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/ToolLaunchEvent"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/ToolUseEvent"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/ViewEvent"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/AssignableDigitalResource"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Chapter"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DigitalResourceCollection"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Document"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Frame"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LtiLink"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaLocation"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaObject"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Message"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Page"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Question"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/WebPage"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -1157,6 +1157,18 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/host -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/host">
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">Identifies the host of a SoftwareApplication. This property can be used to indicate the back-end service or domain hosting a front-end web application.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">host</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/id -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/id">
@@ -1186,6 +1198,18 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A non-negative integer that represents the position of the Frame.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">index</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/ipAddress -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/ipAddress">
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">Indicates the IPv4 or IPv6 address of a SoftwareApplication. This property can be used to indicate the user agent (browser) running a front-end web application.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">ipAddress</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -1713,6 +1737,18 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A string value corresponding to the Class name or label of an Event or Entity.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">type</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/userAgent -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/userAgent">
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">Describes the properties of the user agent hosting a SoftwareApplication. This field can be used to carry the user agent string reported by the browser running a front-end web application.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">userAgent</rdfs:label>
     </owl:DatatypeProperty>
     
 

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -3561,15 +3561,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
                             <owl:Class>
                                 <owl:oneOf rdf:parseType="Collection">
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Archived"/>
-                                    <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Copied"/>
-                                    <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Published"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Restored"/>
-                                    <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Unpublished"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Copied"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Created"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Deleted"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Described"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Downloaded"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Modified"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Printed"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Published"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Retrieved"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Saved"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Unpublished"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Uploaded"/>
                                 </owl:oneOf>
                             </owl:Class>
                         </owl:someValuesFrom>
@@ -4458,16 +4462,6 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
-    <!-- http://purl.imsglobal.org/actions/Copied -->
-
-    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Copied">
-        <rdfs:comment xml:lang="en">Make a replica of.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/201697776-v</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">Copied</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
     <!-- http://purl.imsglobal.org/actions/Launched -->
 
     <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Launched">
@@ -4506,16 +4500,6 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">Go or come back to place, condition, or activity where one has been before.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/01515196-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Returned</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.imsglobal.org/actions/Unpublished -->
-
-    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Unpublished">
-        <rdfs:comment xml:lang="en">Remove from public distribution or sale. Inverse of Published.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/200969657-v</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">Unpublished</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -6408,90 +6392,6 @@ The Caliper ontology provides a machine-readable document that defines the conce
             <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/membership#Officer"/>
         </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDifferent"/>
-        <owl:distinctMembers rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Archived"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Copied"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Launched"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Published"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Restored"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Returned"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Unpublished"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Abandoned"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Activated"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Added"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Attached"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Bookmarked"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/ChangedResolution"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/ChangedSize"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/ChangedSpeed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/ChangedVolume"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Classified"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/ClosedPopout"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Commented"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Completed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Copied"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Created"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Deactivated"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Deleted"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Described"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/DisabledClosedCaptioning"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Disliked"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Downloaded"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/EnabledClosedCaptioning"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Ended"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/EnteredFullScreen"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/ExitedFullScreen"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/ForwardedTo"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Graded"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Hid"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Highlighted"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Identified"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/JumpedTo"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Liked"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Linked"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/LoggedIn"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/LoggedOut"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/MarkedAsRead"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/MarkedAsUnread"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Modified"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Muted"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/NavigatedTo"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/OpenedPopout"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Paused"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Posted"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Printed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Published"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Questioned"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Ranked"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Recommended"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Removed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Reset"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Restarted"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Restored"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Resumed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Retrieved"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Reviewed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Rewound"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Saved"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Searched"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Shared"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Showed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Skipped"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Started"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Submitted"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Subscribed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Tagged"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/TimedOut"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Unmuted"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Unpublished"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Unsubscribed"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Uploaded"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Used"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Viewed"/>
-        </owl:distinctMembers>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDifferent"/>

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -400,6 +400,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
                 <owl:unionOf rdf:parseType="Collection">
                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LikertScale"/>
                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiSelectScale"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiselectQuestion"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -418,6 +419,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
                 <owl:unionOf rdf:parseType="Collection">
                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LikertScale"/>
                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiSelectScale"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiselectQuestion"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -595,7 +597,14 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/question">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Rating"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/QuestionnaireItem"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Rating"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Question"/>
         <rdfs:comment xml:lang="en">The Question used for the Rating.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
@@ -621,7 +630,14 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/rater">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Rating"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Rating"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/SurveyInvitation"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Person"/>
         <rdfs:comment xml:lang="en">The Person who provided the Rating.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
@@ -686,9 +702,16 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/scale">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Rating"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Rating"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/RatingScaleQuestion"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Scale"/>
-        <rdfs:comment xml:lang="en">The Scale used for the Rating.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The Scale associated with the Rating or RatingScaleQuestion.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">scale</rdfs:label>
     </owl:ObjectProperty>
@@ -764,7 +787,15 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <!-- http://purl.imsglobal.org/caliper/selections -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/selections">
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Rating"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiSelectResponse"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Rating"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/RatingScaleResponse"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:comment xml:lang="en">An array of the values representing the rater&apos;s selected response.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">selections</rdfs:label>
@@ -808,6 +839,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">The parent Organization of an Organization.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">subOrganizationOf</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/survey -->
+
+    <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/survey">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SurveyInvitation"/>
+        <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Survey"/>
+        <rdfs:comment xml:lang="en">The Survey that the invitation is for.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">survey</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -896,6 +940,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A plain text rendering of the note associated with a BookmarkAnnotation.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">bookmarkNotes</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/categories -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/categories">
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/QuestionnaireItem"/>
+        <rdfs:comment xml:lang="en">An array of category items.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">categories</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -1042,6 +1097,32 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that provides the publication date of a resource.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">datePublished</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/dateSent -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/dateSent">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SurveyInvitation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when the SurveyInvitation was sent.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">dateSent</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/dateTimeSelected -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/dateTimeSelected">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DateTimeResponse"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <rdfs:comment xml:lang="en">The date and time selected in response to the Question.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">dateTimeSelected</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -1200,6 +1281,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <!-- http://purl.imsglobal.org/caliper/host -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/host">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Identifies the host of a SoftwareApplication. This property can be used to indicate the back-end service or domain hosting a front-end web application.</rdfs:comment>
@@ -1245,6 +1327,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <!-- http://purl.imsglobal.org/caliper/ipAddress -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/ipAddress">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Indicates the IPv4 or IPv6 address of a SoftwareApplication. This property can be used to indicate the user agent (browser) running a front-end web application.</rdfs:comment>
@@ -1292,11 +1375,31 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/maxDateTime -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/maxDateTime">
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DateTimeQuestion"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <owl:propertyDisjointWith rdf:resource="http://purl.imsglobal.org/caliper/minDateTime"/>
+        <rdfs:comment xml:lang="en">A date and time value used to determine the maximum value allowed.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">maxDateTime</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/maxLabel -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/maxLabel">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/NumericScale"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DateTimeQuestion"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/NumericScale"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <owl:propertyDisjointWith rdf:resource="http://purl.imsglobal.org/caliper/minLabel"/>
         <rdfs:comment xml:lang="en">The label for the maximum value.</rdfs:comment>
@@ -1418,11 +1521,30 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/minDateTime -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/minDateTime">
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DateTimeQuestion"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <rdfs:comment xml:lang="en">A date and time value used to determine the minimum value allowed.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">minDateTime</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/minLabel -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/minLabel">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/NumericScale"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DateTimeQuestion"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/NumericScale"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">The label for the minimum value.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
@@ -1541,18 +1663,24 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/points">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LikertScale"/>
-                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiSelectScale"/>
-                </owl:unionOf>
-            </owl:Class>
-        </rdfs:domain>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/MultiselectQuestion"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <rdfs:comment xml:lang="en">A integer value used to determine the amount of points on the LikertScale.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">scalePoints</rdfs:label>
+        <rdfs:comment xml:lang="en">A integer value used to determine the amount of points on the  MultiselectQuestion.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">points</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/questionPosed -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/questionPosed">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Question"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">A string value comprising the question posed.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">questionPosed</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -1566,6 +1694,26 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">The result score awarded to the learner.  A result score can be updated.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">resultScore</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/scalePoints -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/scalePoints">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LikertScale"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiSelectScale"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en">A integer value used to determine the amount of points on the LikertScale.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">scalePoints</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -1644,6 +1792,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">Sensor identifier.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">sensor</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/sentCount -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/sentCount">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SurveyInvitation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en">An integer value used to determine the amount of times a SurveyInvitation was sent to the rater.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">sentCount</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -1759,6 +1920,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <!-- http://purl.imsglobal.org/caliper/userAgent -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/userAgent">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Describes the properties of the user agent hosting a SoftwareApplication. This field can be used to carry the user agent string reported by the browser running a front-end web application.</rdfs:comment>
@@ -1776,6 +1938,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultipleChoiceResponse"/>
+                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/OpenEndedResponse"/>
                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/TrueFalseResponse"/>
                 </owl:unionOf>
             </owl:Class>
@@ -1864,6 +2027,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A string value indicating the minimum volume level permitted.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">volumeMin</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/weight -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/weight">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/QuestionnaireItem"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+        <rdfs:comment xml:lang="en">A decimal value used to determine the weight of the QuestionnaireItem.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">weight</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -2488,6 +2664,28 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/DateTimeQuestion -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/DateTimeQuestion">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Question"/>
+        <rdfs:comment xml:lang="en">A Caliper DateTimeQuestion represents a closed-end question type with the response provided in a date and time format.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">DateTimeQuestion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/DateTimeResponse -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/DateTimeResponse">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
+        <rdfs:comment xml:lang="en">A Caliper DateTimeResponse represents a respondent&apos;s response to a DateTimeQuestion.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">DateTimeResponse</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/DigitalResource -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/DigitalResource">
@@ -2897,7 +3095,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/LtiLink">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
-        <rdfs:comment xml:lang="en">The LtiLink entity represents a digital resource that must be retrieved from an external tool application via an LTI request message. It is, effectively, a Digital Resource that must use LTI for access.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The Caliper LtiLink entity represents a digital resource that must be retrieved from an external tool application via an LTI request message. It is, effectively, a Digital Resource that must use LTI for access.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">LtiLink</rdfs:label>
     </owl:Class>
@@ -3164,6 +3362,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/MultiSelectResponse -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/MultiSelectResponse">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
+        <rdfs:comment xml:lang="en">A Caliper MultiselectResponse represents a response to a MultiselectQuestion in which the respondent is permitted to choose one or more options from a pre-defined set of responses.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">MultiSelectResponse</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/MultiSelectScale -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/MultiSelectScale">
@@ -3193,6 +3402,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A Caliper MultipleResponseResponse represents a form of response in which a respondent is asked to select more than one correct answer from a list of choices.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">MultipleResponseResponse</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/MultiselectQuestion -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/MultiselectQuestion">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Question"/>
+        <rdfs:comment xml:lang="en">A Caliper MultiselectQuestion represents a form of a closed-end question type with a pre-defined set of responses where a respondent can choose multiple items in the set.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">MultiselectQuestion</rdfs:label>
     </owl:Class>
     
 
@@ -3291,6 +3511,28 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A Caliper NumericScale models a numeric scale used to capture some rating.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">NumericScale</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/OpenEndedQuestion -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/OpenEndedQuestion">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Question"/>
+        <rdfs:comment xml:lang="en">A Caliper OpenEndedQuestion represents a question with no pre-defined response. Respondents can record their response in the form of qualitative feedback with no length limit imposed.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">OpenEndedQuestion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/OpenEndedResponse -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/OpenEndedResponse">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
+        <rdfs:comment xml:lang="en">A Caliper OpenEndedResponse represents a respondent&apos;s response to a OpenEndedQuestion.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">OpenEndedResponse</rdfs:label>
     </owl:Class>
     
 
@@ -3432,6 +3674,155 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/Questionnaire -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Questionnaire">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResourceCollection"/>
+        <rdfs:comment xml:lang="en">A Caliper Questionnaire represents a collection of QuestionnaireItem entities that is designed to elicit information from one or more respondents.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Questionnaire</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/QuestionnaireEvent -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/QuestionnaireEvent">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:oneOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Started"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Submitted"/>
+                                </owl:oneOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Person"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Questionnaire"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Caliper QuestionnaireEvent models activities associated with respondents or raters starting and submitting a Questionnaire.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">QuestionnaireEvent</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/QuestionnaireItem -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/QuestionnaireItem">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
+        <rdfs:comment xml:lang="en">A Caliper QuestionnaireItem represents a Question that is associated with a Questionnaire.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">QuestionnaireItem</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/QuestionnaireItemEvent -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/QuestionnaireItemEvent">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:oneOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Completed"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Skipped"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Started"/>
+                                </owl:oneOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Person"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/QuestionnaireItem"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/generated"/>
+                <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Caliper QuestionnaireItemEvent models activities associated with respondents or raters starting, completing, or skipping a QuestionnaireItem.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">QuestionnaireItemEvent</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/Rating -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Rating">
@@ -3459,6 +3850,28 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">A Caliper Rating models quantitative reactions to an Entity.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Rating</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/RatingScaleQuestion -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/RatingScaleQuestion">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Question"/>
+        <rdfs:comment xml:lang="en">A Caliper RatingScaleQuestion represents a Question that employs a Scale.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">RatingScaleQuestion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/RatingScaleResponse -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/RatingScaleResponse">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
+        <rdfs:comment xml:lang="en">A Caliper RatingScaleResponse represents a respondent&apos;s response to a RatingScaleQuestion.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">RatingScaleResponse</rdfs:label>
     </owl:Class>
     
 
@@ -3560,8 +3973,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:oneOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Archived"/>
-                                    <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Restored"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Archived"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Copied"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Created"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Deleted"/>
@@ -3570,6 +3982,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Modified"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Printed"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Published"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Restored"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Retrieved"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Saved"/>
                                     <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Unpublished"/>
@@ -3912,6 +4325,163 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/Survey -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Survey">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Collection"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/items"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/items"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Questionnaire"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Caliper Survey represents a research method for collecting data from a targeted group of respondents. The Survey provides a standardized process for gathering data that utilizes one or more Questionnaire entities.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Survey</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/SurveyEvent -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/SurveyEvent">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:oneOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/OptedIn"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/OptedOut"/>
+                                </owl:oneOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Person"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Survey"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A SurveyEvent models activities associated with calls to participate in a Survey.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">SurveyEvent</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/SurveyInvitation -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/SurveyInvitation">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
+        <rdfs:comment xml:lang="en">A Caliper SurveyInvitation represents a survey invitation sent to raters.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">SurveyInvitation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/SurveyInvitationEvent -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/SurveyInvitationEvent">
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/action"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:oneOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Accepted"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Declined"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Sent"/>
+                                </owl:oneOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/actor"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Person"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.imsglobal.org/caliper/object"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.imsglobal.org/caliper/SurveyInvitation"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Caliper SurveyInvitationEvent models activities associated with calls to participate in a Survey.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">SurveyInvitationEvent</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/TagAnnotation -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/TagAnnotation">
@@ -4049,8 +4619,8 @@ The Caliper ontology provides a machine-readable document that defines the conce
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:oneOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Launched"/>
-                                    <rdf:Description rdf:about="http://purl.imsglobal.org/actions/Returned"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Launched"/>
+                                    <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/actions/Returned"/>
                                 </owl:oneOf>
                             </owl:Class>
                         </owl:someValuesFrom>
@@ -4451,55 +5021,12 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
-    <!-- http://purl.imsglobal.org/actions/Archived -->
-
-    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Archived">
-        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
-        <rdfs:comment xml:lang="en">Put into an archive. The Archived action signals that a resource has been put into long-term storage. Inverse of Restored.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/201387292-v</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">Archived</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.imsglobal.org/actions/Launched -->
-
-    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Launched">
-        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
-        <rdfs:comment xml:lang="en">Get going; give impetus to.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">href=&quot;http://wordnet-rdf.princeton.edu/wn31/01515196-v</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">Launched</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
     <!-- http://purl.imsglobal.org/actions/Published -->
 
     <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Published">
         <rdfs:comment xml:lang="en">Prepare and issue for public distribution or sale. Inverse of Unpublished.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/200969657-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Published</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.imsglobal.org/actions/Restored -->
-
-    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Restored">
-        <rdfs:comment xml:lang="en">Return to its original or usable and functioning condition. Inverse of Archived.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/202558146-v</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">Restored</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.imsglobal.org/actions/Returned -->
-
-    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/actions/Returned">
-        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
-        <rdfs:comment xml:lang="en">Go or come back to place, condition, or activity where one has been before.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/01515196-v</rdfs:isDefinedBy>
-        <rdfs:label xml:lang="en">Returned</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -4680,6 +5207,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/actions/Accepted -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Accepted">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+        <rdfs:comment xml:lang="en">The Accepted action signals that an affirmative reply was given with regard to some Entity. Inverse of Declined.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Accepted</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/actions/Activated -->
 
     <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Activated">
@@ -4698,6 +5236,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">Make an addition (to); join or combine or unite with others; increase the quality, quantity, size or scope of. Inverse of Removed.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/200182551-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Added</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/actions/Archived -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Archived">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+        <rdfs:comment xml:lang="en">Put into an archive. The Archived action signals that a resource has been put into long-term storage. Inverse of Restored.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/201387292-v</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Archived</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -4846,6 +5395,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">Make inactive. Inverse of Activated.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/200191849-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Deactivated</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/actions/Declined -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Declined">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+        <rdfs:comment xml:lang="en">The Declined action signals that a negative reply or refusal was given with regard to some Entity. Inverse of Accepted.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Declined</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -5019,6 +5579,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/actions/Launched -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Launched">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+        <rdfs:comment xml:lang="en">Get going; give impetus to.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">href=&quot;http://wordnet-rdf.princeton.edu/wn31/01515196-v</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Launched</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/actions/Liked -->
 
     <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Liked">
@@ -5128,6 +5699,26 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">OpenedPopout</rdfs:label>
         <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/202431018-v</rdfs:seeAlso>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/actions/OptedIn -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/OptedIn">
+        <rdfs:comment xml:lang="en">The OptedIn action signals that a Person agreed to participate in an activity or complete a task. Inverse of OptedOut.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">OptedIn</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/actions/OptedOut -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/OptedOut">
+        <rdfs:comment xml:lang="en">The OptedOut action signals that a Person declined to participate in an activity or complete a task. Inverse of OptedIn.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">OptedOut</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -5247,6 +5838,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Restored">
         <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+        <rdfs:comment xml:lang="en">Return to its original or usable and functioning condition. Inverse of Archived.</rdfs:comment>
         <rdfs:comment xml:lang="en">Return to its original or usable and functioning condition. The Restored action signals that an archived resource has been retrieved from long-term storage. Inverse of Archived.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/202558146-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Restored</rdfs:label>
@@ -5273,6 +5865,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">Obtain or retrieve from a storage device; as of information on a computer. The Retrieved action signals that a resource has been accessed or obtained.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/202253616-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Retrieved</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/actions/Returned -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Returned">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+        <rdfs:comment xml:lang="en">Go or come back to place, condition, or activity where one has been before.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/01515196-v</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Returned</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -5317,6 +5920,17 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">Try to locate or discover, or try to establish the existence of.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/201318273-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Searched</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/actions/Sent -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/actions/Sent">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
+        <rdfs:comment xml:lang="en">The Sent action signals that some Entity was transmitted or transferred.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Sent</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -6229,6 +6843,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Agent"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/AggregateMeasure"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Annotation"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Attempt"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Comment"/>
@@ -6241,41 +6856,6 @@ The Caliper ontology provides a machine-readable document that defines the conce
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Response"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Result"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Scale"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Score"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/SearchResponse"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Session"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Agent"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Annotation"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Attempt"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DigitalResource"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LearningObjective"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Link"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Membership"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Query"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Response"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Result"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Score"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/SearchResponse"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Session"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Agent"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Annotation"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Attempt"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DigitalResource"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LearningObjective"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Membership"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Query"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Response"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Result"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Score"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/SearchResponse"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Session"/>
@@ -6308,33 +6888,10 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/AssignableDigitalResource"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Chapter"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DigitalResourceCollection"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Document"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Frame"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LtiLink"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaLocation"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaObject"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Message"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Page"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Question"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/WebPage"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/AssignableDigitalResource"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Chapter"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Document"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Frame"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LtiLink"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaLocation"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaObject"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Message"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Page"/>
-            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/WebPage"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Assessment"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Forum"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Questionnaire"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Thread"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
@@ -6357,9 +6914,31 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Chapter"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DigitalResourceCollection"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Document"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Frame"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/LtiLink"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaLocation"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MediaObject"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Message"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Page"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/Question"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/QuestionnaireItem"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/SurveyInvitation"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/WebPage"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/DateTimeResponse"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/FillinBlankResponse"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultiSelectResponse"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultipleChoiceResponse"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/MultipleResponseResponse"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/OpenEndedResponse"/>
+            <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/RatingScaleResponse"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/SelectTextResponse"/>
             <rdf:Description rdf:about="http://purl.imsglobal.org/caliper/TrueFalseResponse"/>
         </owl:members>

--- a/ontology/caliper-rdfxml.owl
+++ b/ontology/caliper-rdfxml.owl
@@ -552,6 +552,19 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/profile -->
+
+    <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/profile">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
+        <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">Named profile that governs the rules of interpretation for an Event. The range of profile values is limited to the set of profiles described by the Caliper specification and any profile extension specifications extending the Caliper specification.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">profile</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/query -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/query">
@@ -3402,6 +3415,12 @@ The Caliper ontology provides a machine-readable document that defines the conce
     
 
 
+    <!-- http://purl.imsglobal.org/caliper/Profile -->
+
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Profile"/>
+    
+
+
     <!-- http://purl.imsglobal.org/caliper/Query -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Query">
@@ -4497,6 +4516,171 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:comment xml:lang="en">Remove from public distribution or sale. Inverse of Published.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wordnet-rdf.princeton.edu/wn31/200969657-v</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Unpublished</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/AnnotationProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/AnnotationProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Annotation Profile models activities related to the annotation of a DigitalResource.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">AnnotationProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/AssessmentProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/AssessmentProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Assessment Profile models assessment-related activities including interactions with individual assessment items.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">AssessmentProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/AssignableProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/AssignableProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Assignable Profile models activities associated with the assignment of digital content to a learner for completion according to specific criteria.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">AssignableProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/FeedbackProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/FeedbackProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Feedback Profile models a Person providing informal feedback on a Entity, typically a piece of student work.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">FeedbackProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/ForumProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/ForumProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Forum Profile models learners and others participating in online discussion forums. Forums typically encompass one or more threads or topics to which members can subscribe, post messages and reply to other messages if a threaded discussion is permitted.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">ForumProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/GeneralProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/GeneralProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Caliper General Profile provides a generic Event for describing learning or supporting activities that have yet to be modeled by Caliper.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">GeneralProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/GradingProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/GradingProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Grading Profile models grading activities performed by an Agent, typically a Person or a SoftwareApplication.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">GradingProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/MediaProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/MediaProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Media Profile models interactions between learners and rich content such as audio, images and video.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">MediaProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/ReadingProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/ReadingProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:isDefinedBy xml:lang="en">The Reading Profile models activities associated with navigating to and viewing digital textual content.</rdfs:isDefinedBy>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">ReadingProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/ResourceManagementProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/ResourceManagementProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Resource Management Profile models a Person managing a DigitalResource.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">ResourceManagementProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/SearchProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/SearchProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Search Profile models an actor, typically a learner, querying a resource for information.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">SearchProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/SessionProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/SessionProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Session Profile models the creation and subsequent termination of a user session established by a Person interacting with a SoftwareApplication.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">SessionProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/SurveyProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/SurveyProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Survey Profile provides a vocabulary for describing events associated with a respondent&apos;s participation in online surveys.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">SurveyProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/ToolLaunchProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/ToolLaunchProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Tool Launch Profile is intended to capture the utilization of learning tools from a centralized location, such as an LTI Tool Platform (often an LMS).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">ToolLaunchProfile</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.imsglobal.org/caliper/ToolUseProfile -->
+
+    <owl:NamedIndividual rdf:about="http://purl.imsglobal.org/caliper/ToolUseProfile">
+        <rdf:type rdf:resource="http://purl.imsglobal.org/caliper/Profile"/>
+        <rdfs:comment xml:lang="en">The Tool Use Profile models an intended interaction between a user and a tool. In other words, when a Person utilizes a SoftwareApplication in a manner that the application determines to be its intended use for learning, an application that implements the Tool Use Profile can emit a ToolUseEvent indicating such usage.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">ToolUseProfile</rdfs:label>
     </owl:NamedIndividual>
     
 

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -160,6 +160,16 @@ xsd:duration rdf:type rdfs:Datatype .
          rdfs:label "attempt"@en .
 
 
+###  http://purl.imsglobal.org/caliper/client
+:client rdf:type owl:ObjectProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:domain :Session ;
+        rdfs:range :SoftwareApplication ;
+        rdfs:comment "The SoftwareApplication that is hosting a Session."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+        rdfs:label "client"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/commentedOn
 :commentedOn rdf:type owl:ObjectProperty ,
                       owl:FunctionalProperty ;

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -401,6 +401,16 @@ xsd:duration rdf:type rdfs:Datatype .
               rdfs:label "organization"@en .
 
 
+###  http://purl.imsglobal.org/caliper/profile
+:profile rdf:type owl:ObjectProperty ,
+                  owl:FunctionalProperty ;
+         rdfs:domain :Event ;
+         rdfs:range :Profile ;
+         rdfs:comment "Named profile that governs the rules of interpretation for an Event. The range of profile values is limited to the set of profiles described by the Caliper specification and any profile extension specifications extending the Caliper specification."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+         rdfs:label "profile"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/query
 :query rdf:type owl:ObjectProperty ,
                 owl:FunctionalProperty ;
@@ -2535,6 +2545,10 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:label "Person"@en .
 
 
+###  http://purl.imsglobal.org/caliper/Profile
+:Profile rdf:type owl:Class .
+
+
 ###  http://purl.imsglobal.org/caliper/Query
 :Query rdf:type owl:Class ;
        rdfs:subClassOf :Entity ;
@@ -3343,6 +3357,126 @@ xsd:duration rdf:type rdfs:Datatype .
                                                 rdfs:comment "Remove from public distribution or sale. Inverse of Published."@en ;
                                                 rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/200969657-v"^^xsd:string ;
                                                 rdfs:label "Unpublished"@en .
+
+
+###  http://purl.imsglobal.org/caliper/AnnotationProfile
+:AnnotationProfile rdf:type owl:NamedIndividual ,
+                            :Profile ;
+                   rdfs:comment "The Annotation Profile models activities related to the annotation of a DigitalResource."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                   rdfs:label "AnnotationProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/AssessmentProfile
+:AssessmentProfile rdf:type owl:NamedIndividual ,
+                            :Profile ;
+                   rdfs:comment "The Assessment Profile models assessment-related activities including interactions with individual assessment items."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                   rdfs:label "AssessmentProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/AssignableProfile
+:AssignableProfile rdf:type owl:NamedIndividual ,
+                            :Profile ;
+                   rdfs:comment "The Assignable Profile models activities associated with the assignment of digital content to a learner for completion according to specific criteria."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                   rdfs:label "AssignableProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/FeedbackProfile
+:FeedbackProfile rdf:type owl:NamedIndividual ,
+                          :Profile ;
+                 rdfs:comment "The Feedback Profile models a Person providing informal feedback on a Entity, typically a piece of student work."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                 rdfs:label "FeedbackProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/ForumProfile
+:ForumProfile rdf:type owl:NamedIndividual ,
+                       :Profile ;
+              rdfs:comment "The Forum Profile models learners and others participating in online discussion forums. Forums typically encompass one or more threads or topics to which members can subscribe, post messages and reply to other messages if a threaded discussion is permitted."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+              rdfs:label "ForumProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/GeneralProfile
+:GeneralProfile rdf:type owl:NamedIndividual ,
+                         :Profile ;
+                rdfs:comment "The Caliper General Profile provides a generic Event for describing learning or supporting activities that have yet to be modeled by Caliper."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                rdfs:label "GeneralProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/GradingProfile
+:GradingProfile rdf:type owl:NamedIndividual ,
+                         :Profile ;
+                rdfs:comment "The Grading Profile models grading activities performed by an Agent, typically a Person or a SoftwareApplication."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                rdfs:label "GradingProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/MediaProfile
+:MediaProfile rdf:type owl:NamedIndividual ,
+                       :Profile ;
+              rdfs:comment "The Media Profile models interactions between learners and rich content such as audio, images and video."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+              rdfs:label "MediaProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/ReadingProfile
+:ReadingProfile rdf:type owl:NamedIndividual ,
+                         :Profile ;
+                rdfs:isDefinedBy "The Reading Profile models activities associated with navigating to and viewing digital textual content."@en ,
+                                 "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                rdfs:label "ReadingProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/ResourceManagementProfile
+:ResourceManagementProfile rdf:type owl:NamedIndividual ,
+                                    :Profile ;
+                           rdfs:comment "The Resource Management Profile models a Person managing a DigitalResource."@en ;
+                           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                           rdfs:label "ResourceManagementProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/SearchProfile
+:SearchProfile rdf:type owl:NamedIndividual ,
+                        :Profile ;
+               rdfs:comment "The Search Profile models an actor, typically a learner, querying a resource for information."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+               rdfs:label "SearchProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/SessionProfile
+:SessionProfile rdf:type owl:NamedIndividual ,
+                         :Profile ;
+                rdfs:comment "The Session Profile models the creation and subsequent termination of a user session established by a Person interacting with a SoftwareApplication."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                rdfs:label "SessionProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/SurveyProfile
+:SurveyProfile rdf:type owl:NamedIndividual ,
+                        :Profile ;
+               rdfs:comment "The Survey Profile provides a vocabulary for describing events associated with a respondent's participation in online surveys."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+               rdfs:label "SurveyProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/ToolLaunchProfile
+:ToolLaunchProfile rdf:type owl:NamedIndividual ,
+                            :Profile ;
+                   rdfs:comment "The Tool Launch Profile is intended to capture the utilization of learning tools from a centralized location, such as an LTI Tool Platform (often an LMS)."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                   rdfs:label "ToolLaunchProfile"@en .
+
+
+###  http://purl.imsglobal.org/caliper/ToolUseProfile
+:ToolUseProfile rdf:type owl:NamedIndividual ,
+                         :Profile ;
+                rdfs:comment "The Tool Use Profile models an intended interaction between a user and a tool. In other words, when a Person utilizes a SoftwareApplication in a manner that the application determines to be its intended use for learning, an application that implements the Tool Use Profile can emit a ToolUseEvent indicating such usage."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                rdfs:label "ToolUseProfile"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/actions/Abandoned

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -525,16 +525,6 @@ xsd:duration rdf:type rdfs:Datatype .
                 rdfs:label "searchProvider"@en .
 
 
-###  http://purl.imsglobal.org/caliper/searchResults
-:searchResults rdf:type owl:ObjectProperty ,
-                        owl:FunctionalProperty ;
-               rdfs:domain :SearchResponse ;
-               rdfs:range :Entity ;
-               rdfs:comment "An ordered collection of entities, typically of type DigitalResource that constitute the results of the search."@en ;
-               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
-               rdfs:label "searchResults"@en .
-
-
 ###  http://purl.imsglobal.org/caliper/searchTarget
 :searchTarget rdf:type owl:ObjectProperty ,
                        owl:FunctionalProperty ;

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -2652,15 +2652,19 @@ xsd:duration rdf:type rdfs:Datatype .
                                                                   owl:onProperty :action ;
                                                                   owl:someValuesFrom [ rdf:type owl:Class ;
                                                                                        owl:oneOf ( <http://purl.imsglobal.org/actions/Archived>
-                                                                                                   <http://purl.imsglobal.org/actions/Copied>
-                                                                                                   <http://purl.imsglobal.org/actions/Published>
                                                                                                    <http://purl.imsglobal.org/actions/Restored>
-                                                                                                   <http://purl.imsglobal.org/actions/Unpublished>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Copied>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Created>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Deleted>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Described>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Downloaded>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Modified>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Printed>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Published>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Retrieved>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Saved>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Unpublished>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Uploaded>
                                                                                                  )
                                                                                      ]
                                                                 ]
@@ -3315,13 +3319,6 @@ xsd:duration rdf:type rdfs:Datatype .
                                              rdfs:label "Archived"@en .
 
 
-###  http://purl.imsglobal.org/actions/Copied
-<http://purl.imsglobal.org/actions/Copied> rdf:type owl:NamedIndividual ;
-                                           rdfs:comment "Make a replica of."@en ;
-                                           rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/201697776-v"^^xsd:string ;
-                                           rdfs:label "Copied"@en .
-
-
 ###  http://purl.imsglobal.org/actions/Launched
 <http://purl.imsglobal.org/actions/Launched> rdf:type owl:NamedIndividual ,
                                                       :Action ;
@@ -3350,13 +3347,6 @@ xsd:duration rdf:type rdfs:Datatype .
                                              rdfs:comment "Go or come back to place, condition, or activity where one has been before."@en ;
                                              rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/01515196-v"^^xsd:string ;
                                              rdfs:label "Returned"@en .
-
-
-###  http://purl.imsglobal.org/actions/Unpublished
-<http://purl.imsglobal.org/actions/Unpublished> rdf:type owl:NamedIndividual ;
-                                                rdfs:comment "Remove from public distribution or sale. Inverse of Published."@en ;
-                                                rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/200969657-v"^^xsd:string ;
-                                                rdfs:label "Unpublished"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/AnnotationProfile
@@ -4788,90 +4778,6 @@ xsd:duration rdf:type rdfs:Datatype .
                 <http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor>
                 <http://purl.imsglobal.org/vocab/lis/v2/membership#Officer>
               )
-] .
-
-
-[ rdf:type owl:AllDifferent ;
-  owl:distinctMembers ( <http://purl.imsglobal.org/actions/Archived>
-                        <http://purl.imsglobal.org/actions/Copied>
-                        <http://purl.imsglobal.org/actions/Launched>
-                        <http://purl.imsglobal.org/actions/Published>
-                        <http://purl.imsglobal.org/actions/Restored>
-                        <http://purl.imsglobal.org/actions/Returned>
-                        <http://purl.imsglobal.org/actions/Unpublished>
-                        <http://purl.imsglobal.org/caliper/actions/Abandoned>
-                        <http://purl.imsglobal.org/caliper/actions/Activated>
-                        <http://purl.imsglobal.org/caliper/actions/Added>
-                        <http://purl.imsglobal.org/caliper/actions/Attached>
-                        <http://purl.imsglobal.org/caliper/actions/Bookmarked>
-                        <http://purl.imsglobal.org/caliper/actions/ChangedResolution>
-                        <http://purl.imsglobal.org/caliper/actions/ChangedSize>
-                        <http://purl.imsglobal.org/caliper/actions/ChangedSpeed>
-                        <http://purl.imsglobal.org/caliper/actions/ChangedVolume>
-                        <http://purl.imsglobal.org/caliper/actions/Classified>
-                        <http://purl.imsglobal.org/caliper/actions/ClosedPopout>
-                        <http://purl.imsglobal.org/caliper/actions/Commented>
-                        <http://purl.imsglobal.org/caliper/actions/Completed>
-                        <http://purl.imsglobal.org/caliper/actions/Copied>
-                        <http://purl.imsglobal.org/caliper/actions/Created>
-                        <http://purl.imsglobal.org/caliper/actions/Deactivated>
-                        <http://purl.imsglobal.org/caliper/actions/Deleted>
-                        <http://purl.imsglobal.org/caliper/actions/Described>
-                        <http://purl.imsglobal.org/caliper/actions/DisabledClosedCaptioning>
-                        <http://purl.imsglobal.org/caliper/actions/Disliked>
-                        <http://purl.imsglobal.org/caliper/actions/Downloaded>
-                        <http://purl.imsglobal.org/caliper/actions/EnabledClosedCaptioning>
-                        <http://purl.imsglobal.org/caliper/actions/Ended>
-                        <http://purl.imsglobal.org/caliper/actions/EnteredFullScreen>
-                        <http://purl.imsglobal.org/caliper/actions/ExitedFullScreen>
-                        <http://purl.imsglobal.org/caliper/actions/ForwardedTo>
-                        <http://purl.imsglobal.org/caliper/actions/Graded>
-                        <http://purl.imsglobal.org/caliper/actions/Hid>
-                        <http://purl.imsglobal.org/caliper/actions/Highlighted>
-                        <http://purl.imsglobal.org/caliper/actions/Identified>
-                        <http://purl.imsglobal.org/caliper/actions/JumpedTo>
-                        <http://purl.imsglobal.org/caliper/actions/Liked>
-                        <http://purl.imsglobal.org/caliper/actions/Linked>
-                        <http://purl.imsglobal.org/caliper/actions/LoggedIn>
-                        <http://purl.imsglobal.org/caliper/actions/LoggedOut>
-                        <http://purl.imsglobal.org/caliper/actions/MarkedAsRead>
-                        <http://purl.imsglobal.org/caliper/actions/MarkedAsUnread>
-                        <http://purl.imsglobal.org/caliper/actions/Modified>
-                        <http://purl.imsglobal.org/caliper/actions/Muted>
-                        <http://purl.imsglobal.org/caliper/actions/NavigatedTo>
-                        <http://purl.imsglobal.org/caliper/actions/OpenedPopout>
-                        <http://purl.imsglobal.org/caliper/actions/Paused>
-                        <http://purl.imsglobal.org/caliper/actions/Posted>
-                        <http://purl.imsglobal.org/caliper/actions/Printed>
-                        <http://purl.imsglobal.org/caliper/actions/Published>
-                        <http://purl.imsglobal.org/caliper/actions/Questioned>
-                        <http://purl.imsglobal.org/caliper/actions/Ranked>
-                        <http://purl.imsglobal.org/caliper/actions/Recommended>
-                        <http://purl.imsglobal.org/caliper/actions/Removed>
-                        <http://purl.imsglobal.org/caliper/actions/Reset>
-                        <http://purl.imsglobal.org/caliper/actions/Restarted>
-                        <http://purl.imsglobal.org/caliper/actions/Restored>
-                        <http://purl.imsglobal.org/caliper/actions/Resumed>
-                        <http://purl.imsglobal.org/caliper/actions/Retrieved>
-                        <http://purl.imsglobal.org/caliper/actions/Reviewed>
-                        <http://purl.imsglobal.org/caliper/actions/Rewound>
-                        <http://purl.imsglobal.org/caliper/actions/Saved>
-                        <http://purl.imsglobal.org/caliper/actions/Searched>
-                        <http://purl.imsglobal.org/caliper/actions/Shared>
-                        <http://purl.imsglobal.org/caliper/actions/Showed>
-                        <http://purl.imsglobal.org/caliper/actions/Skipped>
-                        <http://purl.imsglobal.org/caliper/actions/Started>
-                        <http://purl.imsglobal.org/caliper/actions/Submitted>
-                        <http://purl.imsglobal.org/caliper/actions/Subscribed>
-                        <http://purl.imsglobal.org/caliper/actions/Tagged>
-                        <http://purl.imsglobal.org/caliper/actions/TimedOut>
-                        <http://purl.imsglobal.org/caliper/actions/Unmuted>
-                        <http://purl.imsglobal.org/caliper/actions/Unpublished>
-                        <http://purl.imsglobal.org/caliper/actions/Unsubscribed>
-                        <http://purl.imsglobal.org/caliper/actions/Uploaded>
-                        <http://purl.imsglobal.org/caliper/actions/Used>
-                        <http://purl.imsglobal.org/caliper/actions/Viewed>
-                      )
 ] .
 
 

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -288,6 +288,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain [ rdf:type owl:Class ;
                           owl:unionOf ( :LikertScale
                                         :MultiSelectScale
+                                        :MultiselectQuestion
                                       )
                         ] ;
             rdfs:comment "The ordered list of labels for each point on the Likert scale."@en ;
@@ -300,6 +301,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain [ rdf:type owl:Class ;
                           owl:unionOf ( :LikertScale
                                         :MultiSelectScale
+                                        :MultiselectQuestion
                                       )
                         ] ;
             rdfs:comment "The ordered list of values for each point on the Likert scale."@en ;
@@ -434,7 +436,11 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/question
 :question rdf:type owl:ObjectProperty ,
                    owl:FunctionalProperty ;
-          rdfs:domain :Rating ;
+          rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :QuestionnaireItem
+                                      :Rating
+                                    )
+                      ] ;
           rdfs:range :Question ;
           rdfs:comment "The Question used for the Rating."@en ;
           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
@@ -454,7 +460,11 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/rater
 :rater rdf:type owl:ObjectProperty ,
                 owl:FunctionalProperty ;
-       rdfs:domain :Rating ;
+       rdfs:domain [ rdf:type owl:Class ;
+                     owl:unionOf ( :Rating
+                                   :SurveyInvitation
+                                 )
+                   ] ;
        rdfs:range :Person ;
        rdfs:comment "The Person who provided the Rating."@en ;
        rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
@@ -504,9 +514,13 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/scale
 :scale rdf:type owl:ObjectProperty ,
                 owl:FunctionalProperty ;
-       rdfs:domain :Rating ;
+       rdfs:domain [ rdf:type owl:Class ;
+                     owl:unionOf ( :Rating
+                                   :RatingScaleQuestion
+                                 )
+                   ] ;
        rdfs:range :Scale ;
-       rdfs:comment "The Scale used for the Rating."@en ;
+       rdfs:comment "The Scale associated with the Rating or RatingScaleQuestion."@en ;
        rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
        rdfs:label "scale"@en .
 
@@ -561,7 +575,12 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/selections
 :selections rdf:type owl:ObjectProperty ;
-            rdfs:domain :Rating ;
+            rdfs:domain [ rdf:type owl:Class ;
+                          owl:unionOf ( :MultiSelectResponse
+                                        :Rating
+                                        :RatingScaleResponse
+                                      )
+                        ] ;
             rdfs:comment "An array of the values representing the rater's selected response."@en ;
             rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
             rdfs:label "selections"@en .
@@ -596,6 +615,16 @@ xsd:duration rdf:type rdfs:Datatype .
                    rdfs:comment "The parent Organization of an Organization."@en ;
                    rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
                    rdfs:label "subOrganizationOf"@en .
+
+
+###  http://purl.imsglobal.org/caliper/survey
+:survey rdf:type owl:ObjectProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:domain :SurveyInvitation ;
+        rdfs:range :Survey ;
+        rdfs:comment "The Survey that the invitation is for."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+        rdfs:label "survey"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/target
@@ -659,6 +688,14 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:comment "A plain text rendering of the note associated with a BookmarkAnnotation."@en ;
                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
                rdfs:label "bookmarkNotes"@en .
+
+
+###  http://purl.imsglobal.org/caliper/categories
+:categories rdf:type owl:DatatypeProperty ;
+            rdfs:domain :QuestionnaireItem ;
+            rdfs:comment "An array of category items."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+            rdfs:label "categories"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/category
@@ -772,6 +809,26 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:comment "A date and time value expressed with millisecond precision that provides the publication date of a resource."@en ;
                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
                rdfs:label "datePublished"@en .
+
+
+###  http://purl.imsglobal.org/caliper/dateSent
+:dateSent rdf:type owl:DatatypeProperty ,
+                   owl:FunctionalProperty ;
+          rdfs:domain :SurveyInvitation ;
+          rdfs:range xsd:dateTime ;
+          rdfs:comment "A date and time value expressed with millisecond precision that describes when the SurveyInvitation was sent."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+          rdfs:label "dateSent"@en .
+
+
+###  http://purl.imsglobal.org/caliper/dateTimeSelected
+:dateTimeSelected rdf:type owl:DatatypeProperty ,
+                           owl:FunctionalProperty ;
+                  rdfs:domain :DateTimeResponse ;
+                  rdfs:range xsd:dateTime ;
+                  rdfs:comment "The date and time selected in response to the Question."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                  rdfs:label "dateTimeSelected"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/dateToActivate
@@ -890,7 +947,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/host
-:host rdf:type owl:DatatypeProperty ;
+:host rdf:type owl:DatatypeProperty ,
+               owl:FunctionalProperty ;
       rdfs:domain :SoftwareApplication ;
       rdfs:range xsd:string ;
       rdfs:comment "Identifies the host of a SoftwareApplication. This property can be used to indicate the back-end service or domain hosting a front-end web application."@en ;
@@ -923,7 +981,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/ipAddress
-:ipAddress rdf:type owl:DatatypeProperty ;
+:ipAddress rdf:type owl:DatatypeProperty ,
+                    owl:FunctionalProperty ;
            rdfs:domain :SoftwareApplication ;
            rdfs:range xsd:string ;
            rdfs:comment "Indicates the IPv4 or IPv6 address of a SoftwareApplication. This property can be used to indicate the user agent (browser) running a front-end web application."@en ;
@@ -960,10 +1019,24 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:label "maxAttempts"@en .
 
 
+###  http://purl.imsglobal.org/caliper/maxDateTime
+:maxDateTime rdf:type owl:DatatypeProperty ;
+             rdfs:domain :DateTimeQuestion ;
+             rdfs:range xsd:dateTime ;
+             owl:propertyDisjointWith :minDateTime ;
+             rdfs:comment "A date and time value used to determine the maximum value allowed."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+             rdfs:label "maxDateTime"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/maxLabel
 :maxLabel rdf:type owl:DatatypeProperty ,
                    owl:FunctionalProperty ;
-          rdfs:domain :NumericScale ;
+          rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :DateTimeQuestion
+                                      :NumericScale
+                                    )
+                      ] ;
           rdfs:range xsd:string ;
           owl:propertyDisjointWith :minLabel ;
           rdfs:comment "The label for the maximum value."@en ;
@@ -1056,10 +1129,23 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:label "metricValue"@en .
 
 
+###  http://purl.imsglobal.org/caliper/minDateTime
+:minDateTime rdf:type owl:DatatypeProperty ;
+             rdfs:domain :DateTimeQuestion ;
+             rdfs:range xsd:dateTime ;
+             rdfs:comment "A date and time value used to determine the minimum value allowed."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
+             rdfs:label "minDateTime"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/minLabel
 :minLabel rdf:type owl:DatatypeProperty ,
                    owl:FunctionalProperty ;
-          rdfs:domain :NumericScale ;
+          rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :DateTimeQuestion
+                                      :NumericScale
+                                    )
+                      ] ;
           rdfs:range xsd:string ;
           rdfs:comment "The label for the minimum value."@en ;
           rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
@@ -1151,15 +1237,21 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/points
 :points rdf:type owl:DatatypeProperty ,
                  owl:FunctionalProperty ;
-        rdfs:domain [ rdf:type owl:Class ;
-                      owl:unionOf ( :LikertScale
-                                    :MultiSelectScale
-                                  )
-                    ] ;
+        rdfs:domain :MultiselectQuestion ;
         rdfs:range xsd:integer ;
-        rdfs:comment "A integer value used to determine the amount of points on the LikertScale."@en ;
-        rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
-        rdfs:label "scalePoints"@en .
+        rdfs:comment "A integer value used to determine the amount of points on the  MultiselectQuestion."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+        rdfs:label "points"@en .
+
+
+###  http://purl.imsglobal.org/caliper/questionPosed
+:questionPosed rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
+               rdfs:domain :Question ;
+               rdfs:range xsd:string ;
+               rdfs:comment "A string value comprising the question posed."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+               rdfs:label "questionPosed"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/resultScore
@@ -1170,6 +1262,20 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:comment "The result score awarded to the learner.  A result score can be updated."@en ;
              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
              rdfs:label "resultScore"@en .
+
+
+###  http://purl.imsglobal.org/caliper/scalePoints
+:scalePoints rdf:type owl:DatatypeProperty ,
+                      owl:FunctionalProperty ;
+             rdfs:domain [ rdf:type owl:Class ;
+                           owl:unionOf ( :LikertScale
+                                         :MultiSelectScale
+                                       )
+                         ] ;
+             rdfs:range xsd:integer ;
+             rdfs:comment "A integer value used to determine the amount of points on the LikertScale."@en ;
+             rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
+             rdfs:label "scalePoints"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/scoreGiven
@@ -1230,6 +1336,16 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:comment "Sensor identifier."@en ;
         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
         rdfs:label "sensor"@en .
+
+
+###  http://purl.imsglobal.org/caliper/sentCount
+:sentCount rdf:type owl:DatatypeProperty ,
+                    owl:FunctionalProperty ;
+           rdfs:domain :SurveyInvitation ;
+           rdfs:range xsd:integer ;
+           rdfs:comment "An integer value used to determine the amount of times a SurveyInvitation was sent to the rater."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+           rdfs:label "sentCount"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/start
@@ -1314,7 +1430,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/userAgent
-:userAgent rdf:type owl:DatatypeProperty ;
+:userAgent rdf:type owl:DatatypeProperty ,
+                    owl:FunctionalProperty ;
            rdfs:domain :SoftwareApplication ;
            rdfs:range xsd:string ;
            rdfs:comment "Describes the properties of the user agent hosting a SoftwareApplication. This field can be used to carry the user agent string reported by the browser running a front-end web application."@en ;
@@ -1327,6 +1444,7 @@ xsd:duration rdf:type rdfs:Datatype .
                 owl:FunctionalProperty ;
        rdfs:domain [ rdf:type owl:Class ;
                      owl:unionOf ( :MultipleChoiceResponse
+                                   :OpenEndedResponse
                                    :TrueFalseResponse
                                  )
                    ] ;
@@ -1393,6 +1511,16 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:comment "A string value indicating the minimum volume level permitted."@en ;
            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
            rdfs:label "volumeMin"@en .
+
+
+###  http://purl.imsglobal.org/caliper/weight
+:weight rdf:type owl:DatatypeProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:domain :QuestionnaireItem ;
+        rdfs:range xsd:decimal ;
+        rdfs:comment "A decimal value used to determine the weight of the QuestionnaireItem."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+        rdfs:label "weight"@en .
 
 
 #################################################################
@@ -1854,6 +1982,22 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:label "CourseSection"@en .
 
 
+###  http://purl.imsglobal.org/caliper/DateTimeQuestion
+:DateTimeQuestion rdf:type owl:Class ;
+                  rdfs:subClassOf :Question ;
+                  rdfs:comment "A Caliper DateTimeQuestion represents a closed-end question type with the response provided in a date and time format."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
+                  rdfs:label "DateTimeQuestion"@en .
+
+
+###  http://purl.imsglobal.org/caliper/DateTimeResponse
+:DateTimeResponse rdf:type owl:Class ;
+                  rdfs:subClassOf :Response ;
+                  rdfs:comment "A Caliper DateTimeResponse represents a respondent's response to a DateTimeQuestion."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                  rdfs:label "DateTimeResponse"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/DigitalResource
 :DigitalResource rdf:type owl:Class ;
                  rdfs:subClassOf :Entity ;
@@ -2156,7 +2300,7 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/LtiLink
 :LtiLink rdf:type owl:Class ;
          rdfs:subClassOf :DigitalResource ;
-         rdfs:comment "The LtiLink entity represents a digital resource that must be retrieved from an external tool application via an LTI request message. It is, effectively, a Digital Resource that must use LTI for access."@en ;
+         rdfs:comment "The Caliper LtiLink entity represents a digital resource that must be retrieved from an external tool application via an LTI request message. It is, effectively, a Digital Resource that must use LTI for access."@en ;
          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
          rdfs:label "LtiLink"@en .
 
@@ -2359,6 +2503,14 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:label "Metric"@en .
 
 
+###  http://purl.imsglobal.org/caliper/MultiSelectResponse
+:MultiSelectResponse rdf:type owl:Class ;
+                     rdfs:subClassOf :Response ;
+                     rdfs:comment "A Caliper MultiselectResponse represents a response to a MultiselectQuestion in which the respondent is permitted to choose one or more options from a pre-defined set of responses."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                     rdfs:label "MultiSelectResponse"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/MultiSelectScale
 :MultiSelectScale rdf:type owl:Class ;
                   rdfs:subClassOf :Scale ;
@@ -2381,6 +2533,14 @@ xsd:duration rdf:type rdfs:Datatype .
                           rdfs:comment "A Caliper MultipleResponseResponse represents a form of response in which a respondent is asked to select more than one correct answer from a list of choices."@en ;
                           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
                           rdfs:label "MultipleResponseResponse"@en .
+
+
+###  http://purl.imsglobal.org/caliper/MultiselectQuestion
+:MultiselectQuestion rdf:type owl:Class ;
+                     rdfs:subClassOf :Question ;
+                     rdfs:comment "A Caliper MultiselectQuestion represents a form of a closed-end question type with a pre-defined set of responses where a respondent can choose multiple items in the set."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                     rdfs:label "MultiselectQuestion"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/NavigationEvent
@@ -2453,6 +2613,22 @@ xsd:duration rdf:type rdfs:Datatype .
               rdfs:comment "A Caliper NumericScale models a numeric scale used to capture some rating."@en ;
               rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
               rdfs:label "NumericScale"@en .
+
+
+###  http://purl.imsglobal.org/caliper/OpenEndedQuestion
+:OpenEndedQuestion rdf:type owl:Class ;
+                   rdfs:subClassOf :Question ;
+                   rdfs:comment "A Caliper OpenEndedQuestion represents a question with no pre-defined response. Respondents can record their response in the form of qualitative feedback with no length limit imposed."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                   rdfs:label "OpenEndedQuestion"@en .
+
+
+###  http://purl.imsglobal.org/caliper/OpenEndedResponse
+:OpenEndedResponse rdf:type owl:Class ;
+                   rdfs:subClassOf :Response ;
+                   rdfs:comment "A Caliper OpenEndedResponse represents a respondent's response to a OpenEndedQuestion."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                   rdfs:label "OpenEndedResponse"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/Organization
@@ -2557,6 +2733,117 @@ xsd:duration rdf:type rdfs:Datatype .
                      "http://purl.imsglobal.org/caliper"^^xsd:string .
 
 
+###  http://purl.imsglobal.org/caliper/Questionnaire
+:Questionnaire rdf:type owl:Class ;
+               rdfs:subClassOf :DigitalResourceCollection ;
+               rdfs:comment "A Caliper Questionnaire represents a collection of QuestionnaireItem entities that is designed to elicit information from one or more respondents."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+               rdfs:label "Questionnaire"@en .
+
+
+###  http://purl.imsglobal.org/caliper/QuestionnaireEvent
+:QuestionnaireEvent rdf:type owl:Class ;
+                    rdfs:subClassOf :Event ,
+                                    [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :action ;
+                                                             owl:someValuesFrom :Action
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :action ;
+                                                             owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                  owl:oneOf ( <http://purl.imsglobal.org/caliper/actions/Started>
+                                                                                              <http://purl.imsglobal.org/caliper/actions/Submitted>
+                                                                                            )
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ,
+                                    [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :actor ;
+                                                             owl:someValuesFrom :Agent
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :actor ;
+                                                             owl:allValuesFrom :Person
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ,
+                                    [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :object ;
+                                                             owl:someValuesFrom :Entity
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :object ;
+                                                             owl:allValuesFrom :Questionnaire
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                    rdfs:comment "A Caliper QuestionnaireEvent models activities associated with respondents or raters starting and submitting a Questionnaire."@en ;
+                    rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                    rdfs:label "QuestionnaireEvent"@en .
+
+
+###  http://purl.imsglobal.org/caliper/QuestionnaireItem
+:QuestionnaireItem rdf:type owl:Class ;
+                   rdfs:subClassOf :DigitalResource ;
+                   rdfs:comment "A Caliper QuestionnaireItem represents a Question that is associated with a Questionnaire."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                   rdfs:label "QuestionnaireItem"@en .
+
+
+###  http://purl.imsglobal.org/caliper/QuestionnaireItemEvent
+:QuestionnaireItemEvent rdf:type owl:Class ;
+                        rdfs:subClassOf :Event ,
+                                        [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty :action ;
+                                                                 owl:someValuesFrom :Action
+                                                               ]
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty :action ;
+                                                                 owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                      owl:oneOf ( <http://purl.imsglobal.org/caliper/actions/Completed>
+                                                                                                  <http://purl.imsglobal.org/caliper/actions/Skipped>
+                                                                                                  <http://purl.imsglobal.org/caliper/actions/Started>
+                                                                                                )
+                                                                                    ]
+                                                               ]
+                                                             ) ;
+                                          rdf:type owl:Class
+                                        ] ,
+                                        [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty :actor ;
+                                                                 owl:someValuesFrom :Agent
+                                                               ]
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty :actor ;
+                                                                 owl:allValuesFrom :Person
+                                                               ]
+                                                             ) ;
+                                          rdf:type owl:Class
+                                        ] ,
+                                        [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty :object ;
+                                                                 owl:someValuesFrom :Entity
+                                                               ]
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty :object ;
+                                                                 owl:allValuesFrom :QuestionnaireItem
+                                                               ]
+                                                             ) ;
+                                          rdf:type owl:Class
+                                        ] ,
+                                        [ rdf:type owl:Restriction ;
+                                          owl:onProperty :generated ;
+                                          owl:someValuesFrom :Response
+                                        ] ;
+                        rdfs:comment "A Caliper QuestionnaireItemEvent models activities associated with respondents or raters starting, completing, or skipping a QuestionnaireItem."@en ;
+                        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                        rdfs:label "QuestionnaireItemEvent"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/Rating
 :Rating rdf:type owl:Class ;
         rdfs:subClassOf :Entity ,
@@ -2578,6 +2865,22 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:comment "A Caliper Rating models quantitative reactions to an Entity."@en ;
         rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
         rdfs:label "Rating"@en .
+
+
+###  http://purl.imsglobal.org/caliper/RatingScaleQuestion
+:RatingScaleQuestion rdf:type owl:Class ;
+                     rdfs:subClassOf :Question ;
+                     rdfs:comment "A Caliper RatingScaleQuestion represents a Question that employs a Scale."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                     rdfs:label "RatingScaleQuestion"@en .
+
+
+###  http://purl.imsglobal.org/caliper/RatingScaleResponse
+:RatingScaleResponse rdf:type owl:Class ;
+                     rdfs:subClassOf :Response ;
+                     rdfs:comment "A Caliper RatingScaleResponse represents a respondent's response to a RatingScaleQuestion."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                     rdfs:label "RatingScaleResponse"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/Reading
@@ -2651,8 +2954,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                                                 [ rdf:type owl:Restriction ;
                                                                   owl:onProperty :action ;
                                                                   owl:someValuesFrom [ rdf:type owl:Class ;
-                                                                                       owl:oneOf ( <http://purl.imsglobal.org/actions/Archived>
-                                                                                                   <http://purl.imsglobal.org/actions/Restored>
+                                                                                       owl:oneOf ( <http://purl.imsglobal.org/caliper/actions/Archived>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Copied>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Created>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Deleted>
@@ -2661,6 +2963,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Modified>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Printed>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Published>
+                                                                                                   <http://purl.imsglobal.org/caliper/actions/Restored>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Retrieved>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Saved>
                                                                                                    <http://purl.imsglobal.org/caliper/actions/Unpublished>
@@ -2913,6 +3216,124 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:label "Status"@en .
 
 
+###  http://purl.imsglobal.org/caliper/Survey
+:Survey rdf:type owl:Class ;
+        rdfs:subClassOf :Collection ,
+                        [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                 owl:onProperty :items ;
+                                                 owl:someValuesFrom :Entity
+                                               ]
+                                               [ rdf:type owl:Restriction ;
+                                                 owl:onProperty :items ;
+                                                 owl:allValuesFrom :Questionnaire
+                                               ]
+                                             ) ;
+                          rdf:type owl:Class
+                        ] ;
+        rdfs:comment "A Caliper Survey represents a research method for collecting data from a targeted group of respondents. The Survey provides a standardized process for gathering data that utilizes one or more Questionnaire entities."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+        rdfs:label "Survey"@en .
+
+
+###  http://purl.imsglobal.org/caliper/SurveyEvent
+:SurveyEvent rdf:type owl:Class ;
+             rdfs:subClassOf :Event ,
+                             [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                      owl:onProperty :action ;
+                                                      owl:someValuesFrom :Action
+                                                    ]
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty :action ;
+                                                      owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                           owl:oneOf ( <http://purl.imsglobal.org/caliper/actions/OptedIn>
+                                                                                       <http://purl.imsglobal.org/caliper/actions/OptedOut>
+                                                                                     )
+                                                                         ]
+                                                    ]
+                                                  ) ;
+                               rdf:type owl:Class
+                             ] ,
+                             [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                      owl:onProperty :actor ;
+                                                      owl:someValuesFrom :Agent
+                                                    ]
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty :actor ;
+                                                      owl:allValuesFrom :Person
+                                                    ]
+                                                  ) ;
+                               rdf:type owl:Class
+                             ] ,
+                             [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                      owl:onProperty :object ;
+                                                      owl:someValuesFrom :Entity
+                                                    ]
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty :object ;
+                                                      owl:allValuesFrom :Survey
+                                                    ]
+                                                  ) ;
+                               rdf:type owl:Class
+                             ] ;
+             rdfs:comment "A SurveyEvent models activities associated with calls to participate in a Survey."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+             rdfs:label "SurveyEvent"@en .
+
+
+###  http://purl.imsglobal.org/caliper/SurveyInvitation
+:SurveyInvitation rdf:type owl:Class ;
+                  rdfs:subClassOf :DigitalResource ;
+                  rdfs:comment "A Caliper SurveyInvitation represents a survey invitation sent to raters."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                  rdfs:label "SurveyInvitation"@en .
+
+
+###  http://purl.imsglobal.org/caliper/SurveyInvitationEvent
+:SurveyInvitationEvent rdf:type owl:Class ;
+                       rdfs:subClassOf :Event ,
+                                       [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                owl:onProperty :action ;
+                                                                owl:someValuesFrom :Action
+                                                              ]
+                                                              [ rdf:type owl:Restriction ;
+                                                                owl:onProperty :action ;
+                                                                owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                     owl:oneOf ( <http://purl.imsglobal.org/caliper/actions/Accepted>
+                                                                                                 <http://purl.imsglobal.org/caliper/actions/Declined>
+                                                                                                 <http://purl.imsglobal.org/caliper/actions/Sent>
+                                                                                               )
+                                                                                   ]
+                                                              ]
+                                                            ) ;
+                                         rdf:type owl:Class
+                                       ] ,
+                                       [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                owl:onProperty :actor ;
+                                                                owl:someValuesFrom :Agent
+                                                              ]
+                                                              [ rdf:type owl:Restriction ;
+                                                                owl:onProperty :actor ;
+                                                                owl:allValuesFrom :Person
+                                                              ]
+                                                            ) ;
+                                         rdf:type owl:Class
+                                       ] ,
+                                       [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                owl:onProperty :object ;
+                                                                owl:someValuesFrom :Entity
+                                                              ]
+                                                              [ rdf:type owl:Restriction ;
+                                                                owl:onProperty :object ;
+                                                                owl:allValuesFrom :SurveyInvitation
+                                                              ]
+                                                            ) ;
+                                         rdf:type owl:Class
+                                       ] ;
+                       rdfs:comment "A Caliper SurveyInvitationEvent models activities associated with calls to participate in a Survey."@en ;
+                       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                       rdfs:label "SurveyInvitationEvent"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/TagAnnotation
 :TagAnnotation rdf:type owl:Class ;
                rdfs:subClassOf :Annotation ;
@@ -3014,8 +3435,8 @@ xsd:duration rdf:type rdfs:Datatype .
                                                         [ rdf:type owl:Restriction ;
                                                           owl:onProperty :action ;
                                                           owl:someValuesFrom [ rdf:type owl:Class ;
-                                                                               owl:oneOf ( <http://purl.imsglobal.org/actions/Launched>
-                                                                                           <http://purl.imsglobal.org/actions/Returned>
+                                                                               owl:oneOf ( <http://purl.imsglobal.org/caliper/actions/Launched>
+                                                                                           <http://purl.imsglobal.org/caliper/actions/Returned>
                                                                                          )
                                                                              ]
                                                         ]
@@ -3311,42 +3732,11 @@ xsd:duration rdf:type rdfs:Datatype .
 #    Individuals
 #################################################################
 
-###  http://purl.imsglobal.org/actions/Archived
-<http://purl.imsglobal.org/actions/Archived> rdf:type owl:NamedIndividual ,
-                                                      :Action ;
-                                             rdfs:comment "Put into an archive. The Archived action signals that a resource has been put into long-term storage. Inverse of Restored."@en ;
-                                             rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/201387292-v"^^xsd:string ;
-                                             rdfs:label "Archived"@en .
-
-
-###  http://purl.imsglobal.org/actions/Launched
-<http://purl.imsglobal.org/actions/Launched> rdf:type owl:NamedIndividual ,
-                                                      :Action ;
-                                             rdfs:comment "Get going; give impetus to."@en ;
-                                             rdfs:isDefinedBy "href=\"http://wordnet-rdf.princeton.edu/wn31/01515196-v"^^xsd:string ;
-                                             rdfs:label "Launched"@en .
-
-
 ###  http://purl.imsglobal.org/actions/Published
 <http://purl.imsglobal.org/actions/Published> rdf:type owl:NamedIndividual ;
                                               rdfs:comment "Prepare and issue for public distribution or sale. Inverse of Unpublished."@en ;
                                               rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/200969657-v"^^xsd:string ;
                                               rdfs:label "Published"@en .
-
-
-###  http://purl.imsglobal.org/actions/Restored
-<http://purl.imsglobal.org/actions/Restored> rdf:type owl:NamedIndividual ;
-                                             rdfs:comment "Return to its original or usable and functioning condition. Inverse of Archived."@en ;
-                                             rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/202558146-v"^^xsd:string ;
-                                             rdfs:label "Restored"@en .
-
-
-###  http://purl.imsglobal.org/actions/Returned
-<http://purl.imsglobal.org/actions/Returned> rdf:type owl:NamedIndividual ,
-                                                      :Action ;
-                                             rdfs:comment "Go or come back to place, condition, or activity where one has been before."@en ;
-                                             rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/01515196-v"^^xsd:string ;
-                                             rdfs:label "Returned"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/AnnotationProfile
@@ -3477,6 +3867,14 @@ xsd:duration rdf:type rdfs:Datatype .
                                                       rdfs:label "Abandoned"@en .
 
 
+###  http://purl.imsglobal.org/caliper/actions/Accepted
+<http://purl.imsglobal.org/caliper/actions/Accepted> rdf:type owl:NamedIndividual ,
+                                                              :Action ;
+                                                     rdfs:comment "The Accepted action signals that an affirmative reply was given with regard to some Entity. Inverse of Declined."@en ;
+                                                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                                                     rdfs:label "Accepted"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/actions/Activated
 <http://purl.imsglobal.org/caliper/actions/Activated> rdf:type owl:NamedIndividual ,
                                                                :Action ;
@@ -3491,6 +3889,14 @@ xsd:duration rdf:type rdfs:Datatype .
                                                   rdfs:comment "Make an addition (to); join or combine or unite with others; increase the quality, quantity, size or scope of. Inverse of Removed."@en ;
                                                   rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/200182551-v"^^xsd:string ;
                                                   rdfs:label "Added"@en .
+
+
+###  http://purl.imsglobal.org/caliper/actions/Archived
+<http://purl.imsglobal.org/caliper/actions/Archived> rdf:type owl:NamedIndividual ,
+                                                              :Action ;
+                                                     rdfs:comment "Put into an archive. The Archived action signals that a resource has been put into long-term storage. Inverse of Restored."@en ;
+                                                     rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/201387292-v"^^xsd:string ;
+                                                     rdfs:label "Archived"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/actions/Attached
@@ -3600,6 +4006,14 @@ xsd:duration rdf:type rdfs:Datatype .
                                                         rdfs:comment "Make inactive. Inverse of Activated."@en ;
                                                         rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/200191849-v"^^xsd:string ;
                                                         rdfs:label "Deactivated"@en .
+
+
+###  http://purl.imsglobal.org/caliper/actions/Declined
+<http://purl.imsglobal.org/caliper/actions/Declined> rdf:type owl:NamedIndividual ,
+                                                              :Action ;
+                                                     rdfs:comment "The Declined action signals that a negative reply or refusal was given with regard to some Entity. Inverse of Accepted."@en ;
+                                                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                                                     rdfs:label "Declined"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/actions/Deleted
@@ -3726,6 +4140,14 @@ xsd:duration rdf:type rdfs:Datatype .
                                                      rdfs:label "JumpedTo"@en .
 
 
+###  http://purl.imsglobal.org/caliper/actions/Launched
+<http://purl.imsglobal.org/caliper/actions/Launched> rdf:type owl:NamedIndividual ,
+                                                              :Action ;
+                                                     rdfs:comment "Get going; give impetus to."@en ;
+                                                     rdfs:isDefinedBy "href=\"http://wordnet-rdf.princeton.edu/wn31/01515196-v"^^xsd:string ;
+                                                     rdfs:label "Launched"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/actions/Liked
 <http://purl.imsglobal.org/caliper/actions/Liked> rdf:type owl:NamedIndividual ,
                                                            :Action ;
@@ -3807,6 +4229,20 @@ xsd:duration rdf:type rdfs:Datatype .
                                                          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
                                                          rdfs:label "OpenedPopout"@en ;
                                                          rdfs:seeAlso "http://wordnet-rdf.princeton.edu/wn31/202431018-v"^^xsd:string .
+
+
+###  http://purl.imsglobal.org/caliper/actions/OptedIn
+<http://purl.imsglobal.org/caliper/actions/OptedIn> rdf:type owl:NamedIndividual ;
+                                                    rdfs:comment "The OptedIn action signals that a Person agreed to participate in an activity or complete a task. Inverse of OptedOut."@en ;
+                                                    rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                                                    rdfs:label "OptedIn"@en .
+
+
+###  http://purl.imsglobal.org/caliper/actions/OptedOut
+<http://purl.imsglobal.org/caliper/actions/OptedOut> rdf:type owl:NamedIndividual ;
+                                                     rdfs:comment "The OptedOut action signals that a Person declined to participate in an activity or complete a task. Inverse of OptedIn."@en ;
+                                                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                                                     rdfs:label "OptedOut"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/actions/Paused
@@ -3893,7 +4329,8 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/actions/Restored
 <http://purl.imsglobal.org/caliper/actions/Restored> rdf:type owl:NamedIndividual ,
                                                               :Action ;
-                                                     rdfs:comment "Return to its original or usable and functioning condition. The Restored action signals that an archived resource has been retrieved from long-term storage. Inverse of Archived."@en ;
+                                                     rdfs:comment "Return to its original or usable and functioning condition. Inverse of Archived."@en ,
+                                                                  "Return to its original or usable and functioning condition. The Restored action signals that an archived resource has been retrieved from long-term storage. Inverse of Archived."@en ;
                                                      rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/202558146-v"^^xsd:string ;
                                                      rdfs:label "Restored"@en .
 
@@ -3913,6 +4350,14 @@ xsd:duration rdf:type rdfs:Datatype .
                                                       rdfs:comment "Obtain or retrieve from a storage device; as of information on a computer. The Retrieved action signals that a resource has been accessed or obtained."@en ;
                                                       rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/202253616-v"^^xsd:string ;
                                                       rdfs:label "Retrieved"@en .
+
+
+###  http://purl.imsglobal.org/caliper/actions/Returned
+<http://purl.imsglobal.org/caliper/actions/Returned> rdf:type owl:NamedIndividual ,
+                                                              :Action ;
+                                                     rdfs:comment "Go or come back to place, condition, or activity where one has been before."@en ;
+                                                     rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/01515196-v"^^xsd:string ;
+                                                     rdfs:label "Returned"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/actions/Reviewed
@@ -3945,6 +4390,14 @@ xsd:duration rdf:type rdfs:Datatype .
                                                      rdfs:comment "Try to locate or discover, or try to establish the existence of."@en ;
                                                      rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/wn31/201318273-v"^^xsd:string ;
                                                      rdfs:label "Searched"@en .
+
+
+###  http://purl.imsglobal.org/caliper/actions/Sent
+<http://purl.imsglobal.org/caliper/actions/Sent> rdf:type owl:NamedIndividual ,
+                                                          :Action ;
+                                                 rdfs:comment "The Sent action signals that some Entity was transmitted or transferred."@en ;
+                                                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+                                                 rdfs:label "Sent"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/actions/Shared
@@ -4615,6 +5068,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 [ rdf:type owl:AllDisjointClasses ;
   owl:members ( :Agent
+                :AggregateMeasure
                 :Annotation
                 :Attempt
                 :Comment
@@ -4627,41 +5081,6 @@ xsd:duration rdf:type rdfs:Datatype .
                 :Response
                 :Result
                 :Scale
-                :Score
-                :SearchResponse
-                :Session
-              )
-] .
-
-
-[ rdf:type owl:AllDisjointClasses ;
-  owl:members ( :Agent
-                :Annotation
-                :Attempt
-                :DigitalResource
-                :LearningObjective
-                :Link
-                :Membership
-                :Query
-                :Response
-                :Result
-                :Score
-                :SearchResponse
-                :Session
-              )
-] .
-
-
-[ rdf:type owl:AllDisjointClasses ;
-  owl:members ( :Agent
-                :Annotation
-                :Attempt
-                :DigitalResource
-                :LearningObjective
-                :Membership
-                :Query
-                :Response
-                :Result
                 :Score
                 :SearchResponse
                 :Session
@@ -4694,33 +5113,10 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( :AssignableDigitalResource
-                :Chapter
-                :DigitalResourceCollection
-                :Document
-                :Frame
-                :LtiLink
-                :MediaLocation
-                :MediaObject
-                :Message
-                :Page
-                :Question
-                :WebPage
-              )
-] .
-
-
-[ rdf:type owl:AllDisjointClasses ;
-  owl:members ( :AssignableDigitalResource
-                :Chapter
-                :Document
-                :Frame
-                :LtiLink
-                :MediaLocation
-                :MediaObject
-                :Message
-                :Page
-                :WebPage
+  owl:members ( :Assessment
+                :Forum
+                :Questionnaire
+                :Thread
               )
 ] .
 
@@ -4743,9 +5139,31 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( :FillinBlankResponse
+  owl:members ( :Chapter
+                :DigitalResourceCollection
+                :Document
+                :Frame
+                :LtiLink
+                :MediaLocation
+                :MediaObject
+                :Message
+                :Page
+                :Question
+                :QuestionnaireItem
+                :SurveyInvitation
+                :WebPage
+              )
+] .
+
+
+[ rdf:type owl:AllDisjointClasses ;
+  owl:members ( :DateTimeResponse
+                :FillinBlankResponse
+                :MultiSelectResponse
                 :MultipleChoiceResponse
                 :MultipleResponseResponse
+                :OpenEndedResponse
+                :RatingScaleResponse
                 :SelectTextResponse
                 :TrueFalseResponse
               )

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -369,6 +369,16 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:range :LtiMessageType .
 
 
+###  http://purl.imsglobal.org/caliper/metric
+:metric rdf:type owl:ObjectProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:domain :AggregateMeasure ;
+        rdfs:range :Metric ;
+        rdfs:comment "The standard of measurement associated with the progress value."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+        rdfs:label "metric"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/navigatedFrom
 :navigatedFrom rdf:type owl:ObjectProperty ,
                         owl:FunctionalProperty ;
@@ -1033,15 +1043,6 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:comment "A string value drawn from the list of IANA approved media types and subtypes that identifies the file format of a resource."@en ;
            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
            rdfs:label "mediaType"@en .
-
-
-###  http://purl.imsglobal.org/caliper/metric
-:metric rdf:type owl:DatatypeProperty ;
-        rdfs:subPropertyOf owl:topDataProperty ;
-        rdfs:domain :AggregateMeasure ;
-        rdfs:comment "The standard of measurement associated with the progress value."@en ;
-        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
-        rdfs:label "metric"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/metricValue

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -431,6 +431,16 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:label "query"@en .
 
 
+###  http://purl.imsglobal.org/caliper/question
+:question rdf:type owl:ObjectProperty ,
+                   owl:FunctionalProperty ;
+          rdfs:domain :Rating ;
+          rdfs:range :Question ;
+          rdfs:comment "The Question used for the Rating."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+          rdfs:label "question"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/rated
 :rated rdf:type owl:ObjectProperty ,
                 owl:FunctionalProperty ;
@@ -551,6 +561,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/selections
 :selections rdf:type owl:ObjectProperty ;
+            rdfs:domain :Rating ;
             rdfs:comment "An array of the values representing the rater's selected response."@en ;
             rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
             rdfs:label "selections"@en .
@@ -1149,16 +1160,6 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:comment "A integer value used to determine the amount of points on the LikertScale."@en ;
         rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"^^xsd:string ;
         rdfs:label "scalePoints"@en .
-
-
-###  http://purl.imsglobal.org/caliper/question
-:question rdf:type owl:DatatypeProperty ,
-                   owl:FunctionalProperty ;
-          rdfs:domain :Scale ;
-          rdfs:range xsd:string ;
-          rdfs:comment "A string value comprising the question posed to be scaled."@en ;
-          rdfs:isDefinedBy "https://purl.imsglobal.org/caliper"@en ;
-          rdfs:label "question"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/resultScore
@@ -2546,6 +2547,14 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:comment "A Caliper Query models search criteria created by an actor that targets a searchable resource."@en ;
        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
        rdfs:label "Query"@en .
+
+
+###  http://purl.imsglobal.org/caliper/Question
+:Question rdf:type owl:Class ;
+          rdfs:subClassOf :DigitalResource ;
+          rdfs:comment "A Question is a generic type that represents an interrogative expression designed to elicit information from a respondent, featuring either a closed-end format with a set of predefined responses or an open-ended format."@en ;
+          rdfs:label "Question"@en ,
+                     "http://purl.imsglobal.org/caliper"^^xsd:string .
 
 
 ###  http://purl.imsglobal.org/caliper/Rating
@@ -4690,6 +4699,23 @@ xsd:duration rdf:type rdfs:Datatype .
                 :ToolLaunchEvent
                 :ToolUseEvent
                 :ViewEvent
+              )
+] .
+
+
+[ rdf:type owl:AllDisjointClasses ;
+  owl:members ( :AssignableDigitalResource
+                :Chapter
+                :DigitalResourceCollection
+                :Document
+                :Frame
+                :LtiLink
+                :MediaLocation
+                :MediaObject
+                :Message
+                :Page
+                :Question
+                :WebPage
               )
 ] .
 

--- a/ontology/caliper-turtle.owl
+++ b/ontology/caliper-turtle.owl
@@ -858,6 +858,15 @@ xsd:duration rdf:type rdfs:Datatype .
                   owl:deprecated "true"^^xsd:boolean .
 
 
+###  http://purl.imsglobal.org/caliper/host
+:host rdf:type owl:DatatypeProperty ;
+      rdfs:domain :SoftwareApplication ;
+      rdfs:range xsd:string ;
+      rdfs:comment "Identifies the host of a SoftwareApplication. This property can be used to indicate the back-end service or domain hosting a front-end web application."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+      rdfs:label "host"@en .
+
+
 ###  http://purl.imsglobal.org/caliper/id
 :id rdf:type owl:DatatypeProperty ,
              owl:FunctionalProperty ;
@@ -880,6 +889,15 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:comment "A non-negative integer that represents the position of the Frame."@en ;
        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
        rdfs:label "index"@en .
+
+
+###  http://purl.imsglobal.org/caliper/ipAddress
+:ipAddress rdf:type owl:DatatypeProperty ;
+           rdfs:domain :SoftwareApplication ;
+           rdfs:range xsd:string ;
+           rdfs:comment "Indicates the IPv4 or IPv6 address of a SoftwareApplication. This property can be used to indicate the user agent (browser) running a front-end web application."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+           rdfs:label "ipAddress"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/isTimeDependent
@@ -1281,6 +1299,15 @@ xsd:duration rdf:type rdfs:Datatype .
       rdfs:comment "A string value corresponding to the Class name or label of an Event or Entity."@en ;
       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
       rdfs:label "type"@en .
+
+
+###  http://purl.imsglobal.org/caliper/userAgent
+:userAgent rdf:type owl:DatatypeProperty ;
+           rdfs:domain :SoftwareApplication ;
+           rdfs:range xsd:string ;
+           rdfs:comment "Describes the properties of the user agent hosting a SoftwareApplication. This field can be used to carry the user agent string reported by the browser running a front-end web application."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
+           rdfs:label "userAgent"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/value


### PR DESCRIPTION
This PR adds missing 1.2 terms as well as makes corrections to the Caliper ontology (3 flavors). 

__Terms added__

* Classes: Events
   - QuestionnaireEvent
   - QuestionnaireItemEvent
   - SurveyEvent
    - SurveyInvitationEvent
* Classes: Entities
   - DateTimeQuestion
   - DateTimeResponse
   - MultiSelectResponse
   - MultiSelectQuestion
   - OpenEndedQuestion
   - OpenEndedResponse
   - Question
   - Questionnaire
   - QuestionnaireItem
   - RatingScaleQuestion
   - RatingScaleResponse
   - Survey
   - SurveyInvitation
* Class: Profile + individuals (e.g., AssessmentProfile, etc.)
* Class: Action individuals
   - Accepted
   - Archived
   - Declined
   - Launched
   - OptedIn
   - OptedOut
   - Returned
   - Sent
* Properties
  - categories
  - client
  - dateSent
  - dateTimeSelected
  - host
  - ipAddress
  - maxDateTime
  - maxLabel
  - minDateTime
  - metric
  - profile
  - question
  - questionPosed
  - scalePoints
  - sentCount
  - survey
  - userAgent
  - weight

__Terms Deleted__
* searchResults
