### PR TITLE
fixed broken links; added my name

### DIFF
--- a/caliper-spec-v1p2.html
+++ b/caliper-spec-v1p2.html
@@ -56,6 +56,12 @@
                     role: "Author"
                 },
                 {
+                    name: "Lance E Sloan",
+                    company: "University of Michigan (USA)",
+                    companyURL: "https://umich.edu",
+                    role: "Editor"
+                },
+                {
                     name: "Kara Armstrong",
                     company: "Unizin",
                     companyURL: "https://unizin.org/",
@@ -545,7 +551,7 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
 
             <figure class="example">
                 <figcaption> - Event and Entity identifiers</figcaption>
-                <pre><code data-include="fixtures/v1p2/caliperEventNavigationNavigatedTo.json"></code></pre>
+                <pre><code data-include="fixtures/v1p2/caliperEventNavigationNavigatedToWebPage.json"></code></pre>
             </figure>
         </section>
 
@@ -1260,7 +1266,7 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
             <figcaption> - Attempt JSON-LD</figcaption>
             <pre><code data-include="fixtures/v1p2/caliperEntityAttempt.json"></code></pre>
         </figure>
-        <section id="AudioObject" data-include="fragments/entities/caliper-entity-audioObject.html"></section>
+        <section id="AudioObject" data-include="fragments/entities/caliper-entity-audioobject.html"></section>
         <figure class="example">
             <figcaption> - AudioObject JSON-LD</figcaption>
             <pre><code data-include="fixtures/v1p2/caliperEntityAudioObject.json"></code></pre>
@@ -1537,7 +1543,7 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
             <figcaption> - SharedAnnotation JSON-LD</figcaption>
             <pre><code data-include="fixtures/v1p2/caliperEntitySharedAnnotation.json"></code></pre>
         </figure>
-        <section id="SoftwareApplication" data-include="fragments/entities/caliper-entity-softwareApplication.html"></section>
+        <section id="SoftwareApplication" data-include="fragments/entities/caliper-entity-softwareapplication.html"></section>
         <figure class="example">
             <figcaption> - SoftwareApplication JSON-LD</figcaption>
             <pre><code data-include="fixtures/v1p2/caliperEntitySoftwareApplication.json"></code></pre>
@@ -1648,7 +1654,7 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
         <section id="action-disabledClosedCaptioning" data-include="fragments/actions/caliper-action-disabledclosedcaptioning.html"></section>
         <section id="action-disliked" data-include="fragments/actions/caliper-action-disliked.html"></section>
         <section id="action-downloaded" data-include="fragments/actions/caliper-action-downloaded.html"></section>
-        <section id="action-enabledClosedCaptioning" data-include="fragments/actions/caliper-action-enabledClosedCaptioning.html"></section>
+        <section id="action-enabledClosedCaptioning" data-include="fragments/actions/caliper-action-enabledclosedcaptioning.html"></section>
         <section id="action-ended" data-include="fragments/actions/caliper-action-ended.html"></section>
         <section id="action-enteredFullScreen" data-include="fragments/actions/caliper-action-enteredfullscreen.html"></section>
         <section id="action-exitedFullScreen" data-include="fragments/actions/caliper-action-exitedfullscreen.html"></section>
@@ -1662,7 +1668,7 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superseded by new SearchEvent.
         <section id="action-liked" data-include="fragments/actions/caliper-action-liked.html"></section>
         <section id="action-linked" data-include="fragments/actions/caliper-action-linked.html"></section>
         <section id="action-loggedIn" data-include="fragments/actions/caliper-action-loggedin.html"></section>
-        <section id="action-loggedOut" data-include="fragments/actions/caliper-action-loggedOut.html"></section>
+        <section id="action-loggedOut" data-include="fragments/actions/caliper-action-loggedout.html"></section>
         <section id="action-markedAsRead" data-include="fragments/actions/caliper-action-markedasread.html"></section>
         <section id="action-markedAsUnread" data-include="fragments/actions/caliper-action-markedasunread.html"></section>
         <section id="action-modified" data-include="fragments/actions/caliper-action-modified.html"></section>


### PR DESCRIPTION
* Several links to fragment files were broken.  All were upper/lowercase problems.
* Link to fixture page that no longer exists.  I suspect "WebPage" would be the most generic case to replace it with.
* I added my name as "editor".  I'm not sure that's the correct role for what I've done or whether I placed my name in the right order among the contributors.