### PR TITLE
Add in CaseItemUri system identifier type term

### DIFF
--- a/caliper-spec.md
+++ b/caliper-spec.md
@@ -5871,6 +5871,7 @@ Caliper provides a controlled vocabulary for enumerating the various categories 
 | Term | IRI |
 | :--- | :-- |
 | AccountUserName | http://purl.imsglobal.org/vocab/systemIdentifiers/AccountUserName |
+| CaseItemUri | http://purl.imsglobal.org/vocab/systemIdentifiers/CaseItemUri |
 | EmailAddress | http://purl.imsglobal.org/vocab/systemIdentifiers/EmailAddress |
 | LisSourcedId | http://purl.imsglobal.org/vocab/systemIdentifiers/LisSourcedId |
 | LtiContextId | http://purl.imsglobal.org/vocab/systemIdentifiers/LtiContextId |

--- a/contexts/v1p2/caliper-v1p2.jsonld
+++ b/contexts/v1p2/caliper-v1p2.jsonld
@@ -340,6 +340,7 @@
     "WordsRead": "caliper:metrics/WordsRead",
 
     "AccountUserName": "caliper:systemIdentifiers/AccountUserName",
+    "CaseItemUri": "caliper:systemIdentifiers/CaseItemUri",
     "EmailAddress": "caliper:systemIdentifiers/EmailAddress",
     "LisSourcedId": "caliper:systemIdentifiers/LisSourcedId",
     "LtiContextId": "caliper:systemIdentifiers/LtiContextId",

--- a/fixtures/v1p2/caliperEnvelopeTermSystemIdentifierType.json
+++ b/fixtures/v1p2/caliperEnvelopeTermSystemIdentifierType.json
@@ -22,6 +22,18 @@
       "otherIdentifiers": [
         {
           "type": "SystemIdentifier",
+          "identifier": "https://salt-demo.edplancms.com/ims/case/v1p0/CFItems/04bc8e7e-36d3-4078-bed5-e33e9de98d5c",
+          "identifierType": "CaseItemUri"
+        }
+      ]
+    },
+    {
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
+      "id": "http://purl.imsglobal.org/caliper/Entity",
+      "type": "Entity",
+      "otherIdentifiers": [
+        {
+          "type": "SystemIdentifier",
           "identifier": "jane@example.edu",
           "identifierType": "EmailAddress"
         }

--- a/guides/implementation-guide.md
+++ b/guides/implementation-guide.md
@@ -654,7 +654,7 @@ Wherever CASE-aligned learning objectives are associated to [DigitalResources](h
 
 If the Caliper endpoint is able to retrieve this information from another source then it may be better to not include the <code>LearningObjective</code> to help keep the Caliper Event's JSON smaller.
 
-Here is an example of a CASE <code>LearningObjective</code> with a full object (<code>name</code> and <code>description</code> are _optional_)
+Here is an example of a CASE <code>LearningObjective</code> with a full object (<code>name</code>, <code>description</code>, and <code>otherIdentifiers</code> are _optional_)
 
 <pre><code class="json">
 {
@@ -664,16 +664,24 @@ Here is an example of a CASE <code>LearningObjective</code> with a full object (
   "name": "Reading Assignment: Research techniques",
   "learningObjectives": [
     {
-      "id": "https://case.georgiastandards.org/ims/case/v1p0/CFItems/2f5e8130-46fa-11e7-b197-cd3432e719f9",
+      "id": "urn:uuid:2f5e8130-46fa-11e7-b197-cd3432e719f9",
       "type": "LearningObjective",
       "name": "Research techniques",
-      "description": "ELAGSE1RL1 Ask and answer questions about key details in a text."
+      "description": "ELAGSE1RL1 Ask and answer questions about key details in a text.",
+      "otherIdentifiers": [
+          {
+              "type": "SystemIdentifier",
+              "identifier": "https://case.georgiastandards.org/ims/case/v1p0/CFItems/2f5e8130-46fa-11e7-b197-cd3432e719f9",
+              "identifierType": "CaseItemUri"
+
+          }
+      ]
     }
   ]
 }
 </code></pre>
 
-For brevity, it also valid to just include the <code>id</code> in the <code>learningObjectives</code> array like this:
+For brevity, it is also valid to just include the <code>id</code> in the <code>learningObjectives</code> array like this:
 
 <pre><code class="json">
 {
@@ -682,8 +690,8 @@ For brevity, it also valid to just include the <code>id</code> in the <code>lear
   "type": "AssignableDigitalResource",
   "name": "Reading Assignment: Research techniques",
   "learningObjectives": [
-    "https://case.georgiastandards.org/ims/case/v1p0/CFItems/2f5e8130-46fa-11e7-b197-cd3432e719f9",
-    "https://case.georgiastandards.org/ims/case/v1p0/CFItems/2f5eda0e-46fa-11e7-b90a-62096a00843f"
+    "urn:uuid:2f5e8130-46fa-11e7-b197-cd3432e719f9",
+    "urn:uuid:2f5eda0e-46fa-11e7-b90a-62096a00843f"
   ]
 }
 </code></pre>


### PR DESCRIPTION
Add new system identifier type term:
- Add `CaseItemUri` system identifier term to System Identifier vocab fixture
- Add `CaseItemUri` term to context
- Add `CaseItemUri` term to specification


See also https://github.com/IMSGlobal/caliper-spec/issues/515